### PR TITLE
docs(sprint): add Story 1B.3 for ty type-check cleanup

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -58,7 +58,8 @@ development_status:
   epic-1b: backlog
   1b-1-architectural-boundary-enforcement-scripts: backlog
   1b-2-adk-1-20-0-compatibility-layer: backlog
-  # 1b-3-developer-local-tooling: ABSORBED into Story 1A.1
+  # 1b-3-developer-local-tooling: ABSORBED into Story 1A.1 (original scope)
+  1b-3-clean-up-ty-type-check-diagnostics: backlog
   epic-1b-retrospective: optional
 
   # ── Epic 2: Single-Agent Evolution ──

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -460,6 +460,23 @@ So that I can adopt the library without upgrading my ADK version.
 ### ~~Story 1B.3: Developer Local Tooling~~ — ABSORBED INTO Story 1A.1
 *Pre-commit hook chain, py.typed, docvet config, and isort fix all moved to Story 1A.1 to ensure quality gates are active from the very first story. No remaining scope.*
 
+### Story 1B.3: Clean Up ty Type-Check Diagnostics
+
+As a contributor,
+I want the ty type-check CI gate to pass green,
+So that the type-check workflow is a reliable quality signal and new regressions are immediately visible.
+
+**Acceptance Criteria:**
+
+**Given** ty check currently reports 9 diagnostics (2 errors, 7 warnings) that also fail the CI type-check job on develop
+**When** the cleanup is performed
+**Then** all fixable `unused-type-ignore-comment` warnings are resolved by removing stale `# type: ignore` comments from test files
+**And** the `invalid-argument-type` errors in `engine/proposer.py` are resolved (narrow `Mapping` to `dict` or add explicit casts)
+**And** `uv run ty check` exits 0 with no errors and no warnings
+**And** the CI type-check job passes green
+**And** no test behavior changes — all existing tests still pass
+**And** ty override rules in `pyproject.toml` are reduced to only those that are genuinely unfixable (dynamic BaseModel subclasses, pytest.MonkeyPatch.context() ty bug)
+
 ## Epic 2: Single-Agent Evolution
 
 A developer can evolve a single agent's definition and receive a structured, serializable result with improvement metrics, diffs, mutation attribution, and graceful interrupt support.


### PR DESCRIPTION
The ty type-check CI gate fails on develop with 9 pre-existing diagnostics
that predate all current PRs. This adds a story to track the cleanup.

- Add Story 1B.3 to epics.md with acceptance criteria for resolving all 9 ty diagnostics
- Add story to sprint-status.yaml as backlog under Epic 1B

Test: Documentation only

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Story scope and acceptance criteria completeness

### Related
- Pre-existing ty failures visible on develop CI and PRs 252, 253