### PR TITLE
ci(release): sync uv.lock after release-please version bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,12 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr_branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           # Use PAT to allow created releases to trigger publish workflow
@@ -23,3 +27,32 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  update-lockfile:
+    needs: release-please
+    if: needs.release-please.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release-please PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          ref: ${{ needs.release-please.outputs.pr_branch }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Update uv.lock
+        run: uv lock --upgrade-package gepa-adk
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "uv.lock is already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: update uv.lock after version bump"
+            git push
+          fi


### PR DESCRIPTION
Release-please bumps the version in `pyproject.toml` but never regenerates
`uv.lock`. CI runs `uv lock --check` / `uv sync --locked` which rejects the
stale lockfile, causing every release PR to fail.

- Add `id` and job `outputs` (`prs_created`, `pr_branch`) to the release-please step
- Add `update-lockfile` job that checks out the PR branch, runs
  `uv lock --upgrade-package gepa-adk`, and pushes the updated lockfile
- Use `--upgrade-package` to update only the project version without touching dependency pins

Test: CI only — triggers on next release-please PR

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [ ] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Verify `fromJSON(steps.release.outputs.pr).headBranchName` correctly extracts the PR branch name from release-please v4 output
- PAT token fallback logic for checkout+push

### Related
- Same change applied to adk-secure-sessions and docvet repos