### PR TITLE
fix(release): guard fromJSON with short-circuit to prevent empty parse

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prs_created: ${{ steps.release.outputs.prs_created }}
-      pr_branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+      pr_branch: ${{ steps.release.outputs.prs_created == 'true' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
     steps:
       - name: Run release-please
         id: release


### PR DESCRIPTION
The `pr_branch` output uses `fromJSON(steps.release.outputs.pr)` which fails
when no PR is created because the output is an empty string. GitHub Actions
evaluates all output expressions at job completion regardless of downstream
`if` conditions.

- Guard `fromJSON` with `prs_created == 'true' &&` short-circuit so it only
  parses when the PR output is populated

Test: CI only — the release-please workflow should now succeed on pushes that
don't create/update a release PR

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [ ] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Verify GitHub Actions expression short-circuit evaluation works as expected

### Related
- Fixes failure from #257
- Same fix applied to adk-secure-sessions and docvet repos