### PR TITLE
chore(docs): standardize badges and replace TestPyPI with local smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,14 @@ jobs:
           fi
           echo "Version ${TAG_VERSION} matches — OK"
 
+      - name: Install and verify wheel
+        run: |
+          uv venv /tmp/smoke --python 3.12
+          SMOKE=/tmp/smoke/bin
+          uv pip install --python "$SMOKE/python" dist/*.whl
+          "$SMOKE/python" -c "import gepa_adk; print('Import smoke test — OK')"
+          echo "Wheel installs and imports correctly — OK"
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -54,75 +62,11 @@ jobs:
         continue-on-error: true
 
   # ---------------------------------------------------------------------------
-  # Publish to TestPyPI — validates the package on the staging index first.
-  # Uses OIDC trusted publishing (no stored tokens).
-  # ---------------------------------------------------------------------------
-  publish-testpypi:
-    needs: [build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: testpypi
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-          ignore-empty-workdir: true
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI
-        run: uv publish --trusted-publishing always --check-url https://test.pypi.org/simple/
-        env:
-          UV_PUBLISH_URL: "https://test.pypi.org/legacy/"
-
-  # ---------------------------------------------------------------------------
-  # Smoke test — install from TestPyPI and verify the package works.
-  # Catches packaging mistakes before they reach production PyPI.
-  # ---------------------------------------------------------------------------
-  smoke-test:
-    needs: [publish-testpypi]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-          ignore-empty-workdir: true
-      - run: uv python install 3.12
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for TestPyPI index
-        run: sleep 30
-
-      - name: Create virtual environment
-        run: uv venv
-
-      - name: Install from TestPyPI
-        run: |
-          uv pip install \
-            --index-url https://pypi.org/simple/ \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --refresh \
-            "gepa-adk==${{ steps.version.outputs.version }}"
-
-      - name: Verify import
-        run: uv run --no-project python -c "import gepa_adk; print('Smoke test passed')"
-
-  # ---------------------------------------------------------------------------
   # Publish to PyPI — production release.
   # Uses OIDC trusted publishing (no stored tokens).
   # ---------------------------------------------------------------------------
   publish-pypi:
-    needs: [smoke-test]
+    needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,10 @@ jobs:
           enable-cache: true
       - run: uv python install 3.12
       - run: uv sync --locked --dev
-      - run: uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=85
+      - run: uv run pytest --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85
+      - uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
       - run: uv cache prune --ci
         if: always()
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/gepa-adk/tests.yml?branch=develop)](https://github.com/Alberto-Codes/gepa-adk/actions/workflows/tests.yml)
+[![Coverage](https://codecov.io/gh/Alberto-Codes/gepa-adk/graph/badge.svg)](https://codecov.io/gh/Alberto-Codes/gepa-adk)
+[![PyPI](https://img.shields.io/pypi/v/gepa-adk)](https://pypi.org/project/gepa-adk/)
+[![Python](https://img.shields.io/pypi/pyversions/gepa-adk)](https://pypi.org/project/gepa-adk/)
+[![License](https://img.shields.io/pypi/l/gepa-adk)](https://github.com/Alberto-Codes/gepa-adk/blob/main/LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![docs vetted](https://img.shields.io/badge/docs%20vetted-docvet-purple)](https://github.com/Alberto-Codes/docvet)
+
 # gepa-adk
 
 Evolutionary optimization for Google ADK agents.


### PR DESCRIPTION
gepa-adk had zero README badges and still used the old TestPyPI-gated publish pipeline. This brings it in line with sister projects (docvet, adk-secure-sessions).

- Add 7 standardized badges to README (CI, Coverage, PyPI, Python, License, Ruff, docvet)
- Add `--cov-report=xml` and Codecov upload step to `tests.yml`
- Replace `publish-testpypi` + `smoke-test` jobs with local wheel smoke test in `build` job
- Publish pipeline reduced from 5 jobs to 3 (`build → publish-pypi → docs`)

Test: CI — verify tests.yml passes with codecov upload; review publish.yml diff for 3-job structure

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Badge URLs use `branch=develop` (gepa-adk's default branch) and `tests.yml` (not `ci.yml`)
- Smoke test uses `import gepa_adk` (no `--version` flag available)
- `docs` job dependency chain preserved: `publish-pypi → docs`

### Related
- docvet PR that established the pattern: badge standardization + TestPyPI removal
- adk-secure-sessions applied same changes previously