### PR TITLE
docs: fix broken imports, migrate evolve_sync, and update for 2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,20 @@ Evolve a greeting agent to produce formal, Dickens-style greetings:
 
 ```python
 from google.adk.agents import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
 from gepa_adk import evolve, run_sync, EvolutionConfig, SimpleCriticOutput
+
+model = LiteLlm(model="ollama_chat/llama3.2:latest")
 
 agent = LlmAgent(
     name="greeter",
-    model="gemini-2.5-flash",
+    model=model,
     instruction="Greet the user appropriately.",
 )
 
 critic = LlmAgent(
     name="critic",
-    model="gemini-2.5-flash",
+    model=model,
     instruction="Score for formal, Dickens-style greetings. 0.0-1.0.",
     output_schema=SimpleCriticOutput,
 )
@@ -62,7 +65,7 @@ trainset = [
 config = EvolutionConfig(
     max_iterations=5,
     patience=1,
-    reflection_model="gemini-2.5-flash",
+    reflection_model="ollama_chat/llama3.2:latest",
 )
 result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 print(f"Score: {result.original_score:.2f} -> {result.final_score:.2f}")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Evolutionary optimization for Google ADK agents.
 
 ## What is this?
 
-`gepa-adk` evolves AI agent instructions automatically. Give it an agent and training examples, and it finds better prompts through iterative improvement.
+`gepa-adk` evolves AI agent instructions automatically. Give it an agent and training examples, and it finds better prompts through iterative improvement using genetic algorithms and Pareto frontier selection.
+
+Supports single-agent evolution, multi-agent co-evolution, workflow optimization (Sequential, Loop, Parallel agents), output schema evolution, generation config tuning, and multimodal inputs including video.
+
+## Requirements
+
+- Python 3.12+
+- [Ollama](https://ollama.ai) with a local model (recommended for development), or any model supported by [LiteLLM](https://docs.litellm.ai/)
 
 ## Installation
 
@@ -21,7 +28,8 @@ pip install gepa-adk
 ```
 
 ```bash
-export GOOGLE_API_KEY=your-api-key  # or other ADK-supported model
+# For local models (recommended)
+export OLLAMA_API_BASE=http://localhost:11434
 ```
 
 ## Quick Start
@@ -29,9 +37,8 @@ export GOOGLE_API_KEY=your-api-key  # or other ADK-supported model
 Evolve a greeting agent to produce formal, Dickens-style greetings:
 
 ```python
-import asyncio
 from google.adk.agents import LlmAgent
-from gepa_adk import evolve, EvolutionConfig, SimpleCriticOutput
+from gepa_adk import evolve, run_sync, EvolutionConfig, SimpleCriticOutput
 
 agent = LlmAgent(
     name="greeter",
@@ -55,18 +62,34 @@ trainset = [
 config = EvolutionConfig(
     max_iterations=5,
     patience=1,
-    reflection_model="gemini-2.5-flash",  # Model for generating improvements
+    reflection_model="gemini-2.5-flash",
 )
-result = asyncio.run(evolve(agent, trainset, critic=critic, config=config))
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 print(f"Score: {result.original_score:.2f} -> {result.final_score:.2f}")
 print(result.evolved_components["instruction"])
 ```
 
 ## Examples
 
+**Getting started:**
+
 - [basic_evolution.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/basic_evolution.py) — Single agent with critic
-- [critic_agent.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/critic_agent.py) — Custom critic for stories
-- [multi_agent.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/multi_agent.py) — Multi-agent evolution
+- [critic_agent.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/critic_agent.py) — Story generation with dedicated critic
+- [custom_reflection_prompt.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/custom_reflection_prompt.py) — Custom reflection prompts
+
+**Multi-agent & workflows:**
+
+- [multi_agent.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/multi_agent.py) — Multi-agent co-evolution
+- [loop_agent_evolution.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/loop_agent_evolution.py) — LoopAgent workflow evolution
+- [parallel_agent_evolution.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/parallel_agent_evolution.py) — ParallelAgent workflow evolution
+- [nested_workflow_evolution.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/nested_workflow_evolution.py) — Nested workflow evolution
+
+**Advanced:**
+
+- [schema_evolution_example.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/schema_evolution_example.py) — Output schema evolution
+- [config_evolution_demo.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/config_evolution_demo.py) — Generation config evolution
+- [video_transcription_evolution.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/video_transcription_evolution.py) — Video input evolution
+- [app_runner_integration.py](https://github.com/Alberto-Codes/gepa-adk/blob/HEAD/examples/app_runner_integration.py) — ADK App/Runner integration
 
 ## Documentation
 

--- a/docs/adr/ADR-014-adapter-reorganization.md
+++ b/docs/adr/ADR-014-adapter-reorganization.md
@@ -10,11 +10,12 @@ The `adapters/` directory grew to 11 modules (plus the `stoppers/` sub-package) 
 
 ## Decision
 
-Reorganize `adapters/` into 7 concern-based sub-packages while preserving full backward compatibility through re-exports in `adapters/__init__.py`:
+Reorganize `adapters/` into 9 concern-based sub-packages while preserving full backward compatibility through re-exports in `adapters/__init__.py`:
 
 ```
 adapters/
 ├── __init__.py          # Re-exports preserving old import paths
+├── agents/              # Agent provider protocol implementations
 ├── execution/           # AgentExecutor, TrialBuilder
 ├── scoring/             # CriticScorer, schemas, normalize_feedback
 ├── evolution/           # ADKAdapter, MultiAgentAdapter
@@ -30,7 +31,7 @@ Each sub-package has an `__init__.py` with:
 - A docstring explaining purpose and anticipated growth
 - Imports and re-exports of its public symbols via `__all__`
 
-The root `adapters/__init__.py` re-exports all 33 previously-importable symbols from their new sub-package locations, ensuring `from gepa_adk.adapters import X` continues to work.
+The root `adapters/__init__.py` re-exports all 34 previously-importable symbols from their new sub-package locations, ensuring `from gepa_adk.adapters import X` continues to work.
 
 ## Rationale
 
@@ -43,7 +44,7 @@ The root `adapters/__init__.py` re-exports all 33 previously-importable symbols 
 
 ### Positive
 
-- **Navigation**: 7 focused sub-packages vs 11 flat modules
+- **Navigation**: 9 focused sub-packages vs 11 flat modules
 - **Discoverability**: New contributors can find the right package by concern
 - **Growth path**: Each sub-package can grow independently without polluting siblings
 - **Pattern 1 alignment**: The New Adapter Recipe from the architecture doc now targets `adapters/{concern}/` paths
@@ -60,5 +61,5 @@ The root `adapters/__init__.py` re-exports all 33 previously-importable symbols 
 ## Migration
 
 - **Backward-compatible**: `adapters/__init__.py` re-exports every previously-importable symbol
-- **Deprecation tests**: `tests/unit/adapters/test_adapter_reexports.py` verifies all 33 re-exports resolve to the same objects as their sub-package counterparts
+- **Deprecation tests**: `tests/unit/adapters/test_adapter_reexports.py` verifies all 34 re-exports resolve to the same objects as their sub-package counterparts
 - **Stoppers untouched**: The existing `stoppers/` sub-package was not modified

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -1,199 +1,132 @@
 # Release Process
 
-This document describes how to release `gepa-adk` to PyPI.
+This document describes how `gepa-adk` releases are created and published to PyPI.
 
 ## Overview
 
-Releases are automated via GitHub Actions using:
-- **Trusted Publishing (OIDC)** - no API tokens required
-- **uv** for building and publishing
-- **Attestations** for package provenance
-- **GitHub Pages** deployment for documentation
+Releases are fully automated via [release-please](https://github.com/googleapis/release-please) and GitHub Actions:
 
-## Version Management
+1. **Conventional commits** on `main` are tracked automatically
+2. **release-please** opens/updates a version-bump PR with changelog
+3. **Merging** the PR creates a `v*` tag
+4. **publish.yml** triggers on the tag: build → verify → attest → publish to PyPI → deploy docs
 
-**Single source of truth:** Version is stored in `pyproject.toml` only.
+No manual version bumps, tags, or GitHub Releases are needed.
 
-**Policy:** Version must be bumped in a PR before creating a release. CI will verify the tag matches `pyproject.toml` and fail if it doesn't.
+## How Releases Work
 
-### Bump version locally
+### Step 1: Merge conventional commits to main
 
-```bash
-# Using uv (recommended)
-uv version 0.2.0
+Use [conventional commit](https://www.conventionalcommits.org/) prefixes:
 
-# Or manually edit pyproject.toml
-# [project]
-# version = "0.2.0"
-```
+| Prefix | Bump | Example |
+|--------|------|---------|
+| `feat:` | minor | `feat(engine): add mutation rationale capture` |
+| `fix:` | patch | `fix(scorer): handle empty output` |
+| `feat!:` or `BREAKING CHANGE:` | major | `feat!: remove evolve_sync` |
+| `docs:`, `chore:`, `test:`, `ci:` | none | Hidden from changelog |
 
-Commit and merge to `main`:
+### Step 2: release-please creates a PR
 
-```bash
-git add pyproject.toml
-git commit -m "chore: bump version to 0.2.0"
-git push origin feat/my-feature
-# Create PR, get approved, merge
-```
+After each push to `main`, the `release-please.yml` workflow:
 
-## Creating a Release
+- Analyzes new commits since the last release
+- Opens (or updates) a PR titled `chore(main): release X.Y.Z`
+- Generates a changelog from conventional commits
+- Bumps `pyproject.toml` version via the `extra-files` config
+- An `update-lockfile` job updates `uv.lock` on the PR branch
 
-### Step 1: Create and push tag
+### Step 3: Merge the release PR
 
-After your version bump PR is merged to `main`:
+When the release PR is merged:
 
-```bash
-git checkout main
-git pull origin main
+- release-please creates a `vX.Y.Z` tag (using `RELEASE_PLEASE_TOKEN` PAT)
+- The tag triggers `publish.yml`
 
-# Create tag (note the 'v' prefix)
-git tag v0.2.0
+### Step 4: Automatic publishing
 
-# Push tag to GitHub
-git push origin v0.2.0
-```
+The `publish.yml` workflow:
 
-### Step 2: Create GitHub Release
-
-1. Go to https://github.com/Alberto-Codes/gepa-adk/releases
-2. Click **Draft a new release**
-3. Choose tag: `v0.2.0`
-4. Click **Generate release notes** (auto-generates from PRs)
-5. Edit release notes if needed
-6. Click **Publish release**
-
-### Step 3: Automatic Publishing
-
-Once the release is published, the workflow automatically:
-
-1. **Builds** wheel and sdist
+1. **Builds** wheel and sdist with `uv build`
 2. **Verifies** tag version matches `pyproject.toml`
-3. **Tests** artifacts with smoke tests
-4. **Generates** attestations for provenance
-5. **Publishes** to PyPI or TestPyPI (see below)
-6. **Deploys** documentation to GitHub Pages
+3. **Smoke tests** wheel contents (size limit, no test files)
+4. **Installs** and verifies the wheel in a clean venv
+5. **Publishes** to PyPI via OIDC trusted publishing (no API tokens)
+6. **Generates** attestations for package provenance
+7. **Deploys** documentation to GitHub Pages
 
-## Prerelease vs Final Release
+## Configuration Files
 
-The workflow automatically determines the publish target:
+| File | Purpose |
+|------|---------|
+| `release-please-config.json` | Release type, changelog sections, extra-files |
+| `.release-please-manifest.json` | Current version (`1.0.1`) |
+| `.github/workflows/release-please.yml` | PR creation + lockfile update |
+| `.github/workflows/publish.yml` | Build, verify, publish, docs deploy |
 
-### Prerelease (alpha/beta/rc)
+## Prerelease Versions
 
-Versions containing `a`, `b`, or `rc` are treated as prereleases:
-- `0.2.0a1` - alpha
-- `0.2.0b2` - beta
-- `0.2.0rc1` - release candidate
+Prerelease versions (e.g., `2.0.0a1`, `2.0.0rc1`) are not currently automated via release-please. If needed, use the manual process below.
 
-**Behavior:** Publishes to **TestPyPI only** (not PyPI)
+## Emergency Manual Release
 
-### Final Release
+If release-please is broken or you need an out-of-band release:
 
-Versions without prerelease markers:
-- `0.2.0`
-- `1.0.0`
-
-**Behavior:** Publishes to **PyPI**
-
-## Testing with TestPyPI
-
-### For prereleases
-
-Prereleases automatically publish to TestPyPI. Test the installation:
-
-**Using uv (recommended):**
 ```bash
-uv pip install --index-url https://test.pypi.org/simple/ \
-               --extra-index-url https://pypi.org/simple/ \
-               gepa-adk
+# 1. Bump version in pyproject.toml
+uv version 2.0.1
+
+# 2. Commit and merge to main
+git add pyproject.toml
+git commit -m "chore: bump version to 2.0.1"
+# (merge via PR)
+
+# 3. Create and push tag
+git checkout main && git pull
+git tag v2.0.1
+git push origin v2.0.1
 ```
 
-**Using pip:**
-```bash
-pip install --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            gepa-adk
-```
-
-**Note:** The `--extra-index-url` is needed because dependencies (google-adk, litellm, etc.) are not on TestPyPI.
-
-### Manual TestPyPI publish
-
-To manually publish any version to TestPyPI:
-
-1. Go to **Actions** → **Publish to PyPI**
-2. Click **Run workflow**
-3. Set inputs:
-   - **ref:** Tag or commit (e.g., `v0.2.0`)
-   - **target:** `testpypi`
-4. Click **Run workflow**
-
-### Publishing to both TestPyPI and PyPI
-
-Use manual workflow dispatch with:
-- **target:** `both`
-- **allow_prerelease_to_pypi:** `true` (if prerelease)
-
-## Manual Workflow Dispatch
-
-For testing or special cases, you can manually trigger the workflow:
-
-**Inputs:**
-- **ref** (optional): Tag or commit to build/publish (defaults to current branch)
-- **target** (required):
-  - `testpypi` - Publish to TestPyPI only (default)
-  - `pypi` - Publish to PyPI only
-  - `both` - Publish to both
-- **allow_prerelease_to_pypi** (boolean): Safety switch for publishing prereleases to PyPI
+The `v*` tag triggers `publish.yml` regardless of how it was created.
 
 ## Troubleshooting
 
-### "Version mismatch" error
+### Release PR not appearing
+
+- Check that commits use conventional prefixes (`feat:`, `fix:`)
+- Verify `RELEASE_PLEASE_TOKEN` secret is set (PAT with `repo` scope)
+- Check the release-please workflow run in Actions for errors
+
+### Tag not triggering publish
+
+- Tags created by `GITHUB_TOKEN` do NOT trigger other workflows
+- The `RELEASE_PLEASE_TOKEN` PAT is required for cross-workflow triggering
+- Verify the tag matches the `v*` pattern
+
+### "Version mismatch" error in publish
 
 ```
-ERROR: Version mismatch!
-  Tag version:      0.2.0
-  pyproject.toml:   0.1.0
+ERROR: Tag version 2.0.0 does not match pyproject.toml version 1.0.1
 ```
 
-**Fix:** Bump version in `pyproject.toml` first, merge PR, then create tag.
+The tag version must match `pyproject.toml`. release-please handles this automatically; manual tags require a matching version bump first.
 
 ### "OIDC token request failed"
 
-**Fix:** Ensure Trusted Publishing is configured:
-- PyPI: https://pypi.org/manage/account/publishing/
-- TestPyPI: https://test.pypi.org/manage/account/publishing/
+Ensure Trusted Publishing is configured at [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing/):
 
-Required settings:
 - Workflow: `.github/workflows/publish.yml`
 - Repository: `Alberto-Codes/gepa-adk`
-- Environment (optional): Leave blank or use `testpypi` if you've defined a GitHub Environment
+- Environment: `pypi`
 
 ### "Package already exists"
 
-You're trying to republish an existing version. PyPI doesn't allow overwriting.
+PyPI does not allow overwriting published versions. Bump the version and release again.
 
-**Fix:** Bump version and create new release.
+## Version Numbering
 
-### Docs not deploying
+Follows [Semantic Versioning](https://semver.org/):
 
-**Fix:** Ensure GitHub Pages is configured:
-- Settings → Pages → Source: **GitHub Actions**
-
-## Version Numbering Guidelines
-
-Follow [Semantic Versioning](https://semver.org/):
-
-- **MAJOR** (1.0.0): Incompatible API changes
-- **MINOR** (0.2.0): New features, backwards-compatible
-- **PATCH** (0.1.1): Bug fixes, backwards-compatible
-
-**Prerelease identifiers:**
-- `a` - alpha (early testing, unstable)
-- `b` - beta (feature complete, testing)
-- `rc` - release candidate (stable, final testing)
-
-Examples:
-- `0.1.0` → `0.1.1` (bug fix)
-- `0.1.0` → `0.2.0` (new feature)
-- `0.2.0` → `0.2.0rc1` → `0.2.0` (prerelease → final)
-- `0.9.0` → `1.0.0` (breaking change)
+- **MAJOR** (2.0.0): Incompatible API changes
+- **MINOR** (2.1.0): New features, backwards-compatible
+- **PATCH** (2.0.1): Bug fixes, backwards-compatible

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -24,7 +24,8 @@ Use [conventional commit](https://www.conventionalcommits.org/) prefixes:
 | `feat:` | minor | `feat(engine): add mutation rationale capture` |
 | `fix:` | patch | `fix(scorer): handle empty output` |
 | `feat!:` or `BREAKING CHANGE:` | major | `feat!: remove evolve_sync` |
-| `docs:`, `chore:`, `test:`, `ci:` | none | Hidden from changelog |
+| `docs:` | none | Shown in "Documentation" section of changelog |
+| `chore:`, `test:`, `ci:` | none | Hidden from changelog |
 
 ### Step 2: release-please creates a PR
 
@@ -60,7 +61,7 @@ The `publish.yml` workflow:
 | File | Purpose |
 |------|---------|
 | `release-please-config.json` | Release type, changelog sections, extra-files |
-| `.release-please-manifest.json` | Current version (`1.0.1`) |
+| `.release-please-manifest.json` | Current version manifest (see file for current value) |
 | `.github/workflows/release-please.yml` | PR creation + lockfile update |
 | `.github/workflows/publish.yml` | Build, verify, publish, docs deploy |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,10 +89,10 @@ trainset = [
 
 ### Step 4: Run Evolution
 
-Use `evolve_sync()` with the critic to optimize the agent's instruction:
+Use `run_sync(evolve(...))` with the critic to optimize the agent's instruction:
 
 ```python
-from gepa_adk import evolve_sync, EvolutionConfig
+from gepa_adk import evolve, run_sync, EvolutionConfig
 
 # Configure evolution parameters
 config = EvolutionConfig(
@@ -102,7 +102,7 @@ config = EvolutionConfig(
 )
 
 # Run evolution with critic
-result = evolve_sync(agent, trainset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 
 # View results
 print(f"Original score: {result.original_score:.2f}")
@@ -188,7 +188,8 @@ config = EvolutionConfig(
 - **[Architecture Decision Records](adr/index.md)** — Design rationale and patterns
 - **[Examples Directory](https://github.com/Alberto-Codes/gepa-adk/tree/HEAD/examples)** — Working code examples
 
-### Advanced Topics (Coming Soon)
+### Advanced Topics
 
-- Multi-Agent Evolution — Evolve multiple agents together
-- Workflow Optimization — Optimize SequentialAgent pipelines
+- **[Multi-Agent Evolution](guides/multi-agent.md)** — Evolve multiple agents together
+- **[Workflow Evolution](guides/workflows.md)** — Optimize SequentialAgent, LoopAgent, and ParallelAgent pipelines
+- **[Schema Evolution](guides/single-agent.md#advanced-output-schema-evolution)** — Evolve output schemas alongside instructions

--- a/docs/guides/critic-agents.md
+++ b/docs/guides/critic-agents.md
@@ -99,7 +99,7 @@ critic = LlmAgent(
 ### Step 3: Run Evolution
 
 ```python
-from gepa_adk import evolve_sync, EvolutionConfig
+from gepa_adk import evolve, run_sync, EvolutionConfig
 
 trainset = [
     {"input": "A robot learns to paint"},
@@ -112,7 +112,7 @@ config = EvolutionConfig(
     reflection_model="ollama_chat/llama3.2:latest",
 )
 
-result = evolve_sync(agent, trainset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 ```
 
 ## Built-in Critic Schemas
@@ -148,7 +148,7 @@ from gepa_adk import CriticOutput
 Generic instructions for quick setup:
 
 ```python
-from gepa_adk.adapters.critic_scorer import (
+from gepa_adk.adapters import (
     SIMPLE_CRITIC_INSTRUCTION,
     ADVANCED_CRITIC_INSTRUCTION,
 )
@@ -200,7 +200,7 @@ critic = SequentialAgent(
     sub_agents=[context_gatherer, scorer],
 )
 
-result = evolve_sync(agent, trainset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 ```
 
 ### Custom Scorer Protocol
@@ -253,7 +253,7 @@ agent = LlmAgent(
 )
 
 # No critic needed - score extracted from output_schema
-result = evolve_sync(agent, trainset, config=config)
+result = run_sync(evolve(agent, trainset, config=config))
 ```
 
 !!! warning "Self-Assessment Bias"
@@ -306,7 +306,7 @@ This ensures consistent input to reflection regardless of your schema.
 ## API Reference
 
 - [`evolve()`][gepa_adk.api.evolve] — Async evolution
-- [`evolve_sync()`][gepa_adk.api.evolve_sync] — Sync evolution
+- [`run_sync()`][gepa_adk.api.run_sync] — Sync wrapper for async evolution
 - [`SimpleCriticOutput`][gepa_adk.adapters.critic_scorer.SimpleCriticOutput] — Basic schema
 - [`CriticOutput`][gepa_adk.adapters.critic_scorer.CriticOutput] — Advanced schema
 - [`Scorer`][gepa_adk.ports.scorer.Scorer] — Protocol for custom scorers

--- a/docs/guides/critic-agents.md
+++ b/docs/guides/critic-agents.md
@@ -307,6 +307,6 @@ This ensures consistent input to reflection regardless of your schema.
 
 - [`evolve()`][gepa_adk.api.evolve] — Async evolution
 - [`run_sync()`][gepa_adk.api.run_sync] — Sync wrapper for async evolution
-- [`SimpleCriticOutput`][gepa_adk.adapters.critic_scorer.SimpleCriticOutput] — Basic schema
-- [`CriticOutput`][gepa_adk.adapters.critic_scorer.CriticOutput] — Advanced schema
+- [`SimpleCriticOutput`][gepa_adk.adapters.scoring.critic_scorer.SimpleCriticOutput] — Basic schema
+- [`CriticOutput`][gepa_adk.adapters.scoring.critic_scorer.CriticOutput] — Advanced schema
 - [`Scorer`][gepa_adk.ports.scorer.Scorer] — Protocol for custom scorers

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -268,8 +268,7 @@ For advanced use cases with explicit executor:
 
 ```python
 from google.adk.sessions import InMemorySessionService
-from gepa_adk.adapters.agent_executor import AgentExecutor
-from gepa_adk.adapters.multi_agent import MultiAgentAdapter
+from gepa_adk.adapters import AgentExecutor, MultiAgentAdapter
 
 session_service = InMemorySessionService()
 executor = AgentExecutor(session_service=session_service)

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -372,4 +372,4 @@ result = await evolve_group(
 - [`evolve_group()`][gepa_adk.api.evolve_group] — Multi-agent evolution
 - [`MultiAgentEvolutionResult`][gepa_adk.domain.MultiAgentEvolutionResult] — Result type
 - [`EvolutionConfig`][gepa_adk.domain.EvolutionConfig] — Configuration options
-- [`CriticOutput`][gepa_adk.adapters.critic_scorer.CriticOutput] — Critic schema
+- [`CriticOutput`][gepa_adk.adapters.scoring.critic_scorer.CriticOutput] — Critic schema

--- a/docs/guides/reflection-prompts.md
+++ b/docs/guides/reflection-prompts.md
@@ -156,7 +156,7 @@ You can import and extend the default prompt template:
 
 ```python
 from gepa_adk import evolve, EvolutionConfig
-from gepa_adk.engine.adk_reflection import REFLECTION_INSTRUCTION
+from gepa_adk.engine import REFLECTION_INSTRUCTION
 
 # Add domain-specific context to the default
 custom_prompt = REFLECTION_INSTRUCTION + """
@@ -394,7 +394,7 @@ WARNING: reflection_prompt is missing {trials} placeholder
 Before running evolution, test your prompt manually:
 
 ```python
-from gepa_adk.engine.adk_reflection import REFLECTION_INSTRUCTION
+from gepa_adk.engine import REFLECTION_INSTRUCTION
 
 # See what the default looks like
 print(REFLECTION_INSTRUCTION)

--- a/docs/guides/single-agent.md
+++ b/docs/guides/single-agent.md
@@ -91,7 +91,7 @@ trainset = [
 ### Step 4: Run Evolution
 
 ```python
-from gepa_adk import evolve_sync, EvolutionConfig
+from gepa_adk import evolve, run_sync, EvolutionConfig
 
 config = EvolutionConfig(
     max_iterations=5,
@@ -99,7 +99,7 @@ config = EvolutionConfig(
     reflection_model="ollama_chat/llama3.2:latest",
 )
 
-result = evolve_sync(agent, trainset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 
 print(f"Original score: {result.original_score:.3f}")
 print(f"Final score: {result.final_score:.3f}")
@@ -206,7 +206,7 @@ examples = [
 trainset = examples[:8]   # 80% for training
 valset = examples[8:]     # 20% for validation
 
-result = evolve_sync(agent, trainset, valset=valset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, valset=valset, critic=critic, config=config))
 ```
 
 ### Stop Callbacks
@@ -228,14 +228,14 @@ See the [Stop Callbacks Guide](stoppers.md) for more options.
 
 ### Async vs Sync
 
-Use `evolve()` for async contexts, `evolve_sync()` for scripts:
+Use `evolve()` for async contexts, `run_sync(evolve(...))` for scripts:
 
 ```python
 # Async
 result = await evolve(agent, trainset, critic=critic, config=config)
 
 # Sync (wraps async internally)
-result = evolve_sync(agent, trainset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 ```
 
 ## Advanced: Output Schema Evolution
@@ -265,13 +265,13 @@ agent = LlmAgent(
 )
 
 # Evolve just the output schema
-result = evolve_sync(
+result = run_sync(evolve(
     agent,
     trainset,
     critic=critic,
     components=["output_schema"],
     config=config,
-)
+))
 
 print(result.evolved_components["output_schema"])
 ```
@@ -279,13 +279,13 @@ print(result.evolved_components["output_schema"])
 ### Evolving Both
 
 ```python
-result = evolve_sync(
+result = run_sync(evolve(
     agent,
     trainset,
     critic=critic,
     components=["instruction", "output_schema"],
     config=config,
-)
+))
 ```
 
 ### Using Evolved Schemas
@@ -322,13 +322,13 @@ agent = LlmAgent(
     ),
 )
 
-result = evolve_sync(
+result = run_sync(evolve(
     agent,
     trainset,
     critic=critic,
     components=["generate_content_config"],
     config=config,
-)
+))
 
 print(result.evolved_components["generate_content_config"])
 ```
@@ -342,6 +342,6 @@ print(result.evolved_components["generate_content_config"])
 ## API Reference
 
 - [`evolve()`][gepa_adk.api.evolve] — Async evolution
-- [`evolve_sync()`][gepa_adk.api.evolve_sync] — Sync evolution
+- [`run_sync()`][gepa_adk.api.run_sync] — Sync wrapper for async evolution
 - [`EvolutionConfig`][gepa_adk.domain.models.EvolutionConfig] — Configuration
 - [`EvolutionResult`][gepa_adk.domain.models.EvolutionResult] — Results

--- a/docs/guides/stoppers.md
+++ b/docs/guides/stoppers.md
@@ -35,7 +35,7 @@ Use stop callbacks when you need:
 Control API costs by limiting total evaluations:
 
 ```python
-from gepa_adk import EvolutionConfig
+from gepa_adk import evolve, run_sync, EvolutionConfig
 from gepa_adk.adapters.stoppers import MaxEvaluationsStopper
 
 # Stop after 1000 total evaluations
@@ -44,7 +44,7 @@ config = EvolutionConfig(
     stop_callbacks=[MaxEvaluationsStopper(1000)],
 )
 
-result = evolve_sync(agent, trainset, config=config)
+result = run_sync(evolve(agent, trainset, config=config))
 ```
 
 **Why use this?** Each evaluation typically corresponds to one model API call.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ uv add gepa-adk
 ```python
 from google.adk.agents import LlmAgent
 from google.adk.models.lite_llm import LiteLlm
-from gepa_adk import evolve_sync, EvolutionConfig, SimpleCriticOutput
+from gepa_adk import evolve, run_sync, EvolutionConfig, SimpleCriticOutput
 
 agent = LlmAgent(
     name="greeter",
@@ -70,7 +70,7 @@ config = EvolutionConfig(
     patience=2,
     reflection_model="ollama_chat/llama3.2:latest",
 )
-result = evolve_sync(agent, trainset, critic=critic, config=config)
+result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 
 print(f"Improved by {result.improvement:.0%}")
 print(result.evolved_components["instruction"])

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -86,7 +86,7 @@ evolution:evolution
 
     **Scope:** High-level process and outcomes.
 
-    **Usage:** User-facing API (`evolve()`, `evolve_sync()`, `evolve_group()`), result types (`EvolutionResult`, `EvolutionConfig`), field prefixes (`evolved_components`).
+    **Usage:** User-facing API (`evolve()`, `run_sync()`, `evolve_group()`), result types (`EvolutionResult`, `EvolutionConfig`), field prefixes (`evolved_components`).
 
 evolution:mutation
 :   A genetic operator that modifies a single candidate to produce an improved

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,7 +8,7 @@ This reference documents all public APIs in gepa-adk.
 
 ### Core Evolution Functions
 - **[`evolve()`](gepa_adk/api.md#gepa_adk.api.evolve)** — Async single-agent evolution
-- **[`evolve_sync()`](gepa_adk/api.md#gepa_adk.api.evolve_sync)** — Sync single-agent evolution
+- **[`run_sync()`](gepa_adk/api.md#gepa_adk.api.run_sync)** — Sync wrapper for async evolution
 - **[`evolve_group()`](gepa_adk/api.md#gepa_adk.api.evolve_group)** — Multi-agent co-evolution
 - **[`evolve_workflow()`](gepa_adk/api.md#gepa_adk.api.evolve_workflow)** — Workflow agent evolution
 
@@ -53,10 +53,10 @@ For complete documentation of all modules, classes, and functions:
 
 **Single-agent evolution:**
 ```python
-from gepa_adk import evolve_sync
-result = evolve_sync(agent, trainset, critic=critic)
+from gepa_adk import evolve, run_sync
+result = run_sync(evolve(agent, trainset, critic=critic))
 ```
-See [`evolve_sync()`](gepa_adk/api.md#gepa_adk.api.evolve_sync) for details.
+See [`run_sync()`](gepa_adk/api.md#gepa_adk.api.run_sync) for details.
 
 **Multi-agent evolution:**
 ```python
@@ -67,8 +67,9 @@ See [`evolve_group()`](gepa_adk/api.md#gepa_adk.api.evolve_group) for details.
 
 **State token preservation:**
 ```python
+from gepa_adk import evolve, run_sync
 from gepa_adk.utils import StateGuard
 guard = StateGuard(state_keys=["conversation_id", "user_id"])
-result = evolve_sync(agent, trainset, state_guard=guard)
+result = run_sync(evolve(agent, trainset, state_guard=guard))
 ```
 See [`StateGuard`](gepa_adk/utils/state_guard.md#gepa_adk.utils.state_guard.StateGuard) for details.

--- a/examples/critic_agent.py
+++ b/examples/critic_agent.py
@@ -1,7 +1,8 @@
 """Example: Evolution with critic agent.
 
 This example shows how to use a dedicated critic agent for scoring
-during evolution, separating generation from evaluation.
+during evolution, separating generation from evaluation. Uses
+``run_sync(evolve(...))`` for synchronous execution.
 
 Prerequisites:
     - Python 3.12+
@@ -10,6 +11,16 @@ Prerequisites:
 
 Usage:
     python examples/critic_agent.py
+
+Examples:
+    Run from the repository root:
+
+    ```bash
+    python examples/critic_agent.py
+    ```
+
+See Also:
+    - :mod:`gepa_adk.api` — Public API entry points.
 """
 
 from __future__ import annotations
@@ -22,7 +33,7 @@ from google.adk.agents import LlmAgent
 from google.adk.models.lite_llm import LiteLlm
 from pydantic import BaseModel, Field
 
-from gepa_adk import EvolutionConfig, EvolutionResult, evolve_sync
+from gepa_adk import EvolutionConfig, EvolutionResult, evolve, run_sync
 from gepa_adk.utils import EncodingSafeProcessor
 
 # -----------------------------------------------------------------------------
@@ -73,8 +84,13 @@ class StoryOutput(BaseModel):
     """Output from the storytelling agent.
 
     Attributes:
-        story: The generated story content.
-        genre: The genre of the story.
+        story (str): The generated story content.
+        genre (str): The genre of the story.
+
+    Examples:
+        ```python
+        output = StoryOutput(story="Once upon a time...", genre="fantasy")
+        ```
     """
 
     story: str
@@ -85,10 +101,15 @@ class CriticOutput(BaseModel):
     """Output from the critic agent.
 
     Attributes:
-        score: Overall quality score (0.0-1.0).
-        feedback: Detailed feedback on the story.
-        dimension_scores: Per-dimension scores for story evaluation.
-        actionable_guidance: Specific improvement suggestions.
+        score (float): Overall quality score (0.0-1.0).
+        feedback (str): Detailed feedback on the story.
+        dimension_scores (dict[str, float]): Per-dimension scores for story evaluation.
+        actionable_guidance (str): Specific improvement suggestions.
+
+    Examples:
+        ```python
+        output = CriticOutput(score=0.8, feedback="Good story")
+        ```
     """
 
     score: float = Field(
@@ -166,7 +187,7 @@ def run_evolution(
     critic: LlmAgent,
     trainset: list[dict[str, Any]],
 ) -> EvolutionResult:
-    """Run evolution with critic scoring.
+    """Run evolution with critic scoring via ``run_sync(evolve(...))``.
 
     Args:
         agent: The main agent to evolve.
@@ -188,7 +209,7 @@ def run_evolution(
         trainset_size=len(trainset),
     )
 
-    result = evolve_sync(agent, trainset, critic=critic, config=config)
+    result = run_sync(evolve(agent, trainset, critic=critic, config=config))
 
     logger.info(
         "evolution.complete",
@@ -201,7 +222,11 @@ def run_evolution(
 
 
 def main() -> None:
-    """Run the critic agent evolution example."""
+    """Run the critic agent evolution example.
+
+    Raises:
+        ValueError: If OLLAMA_API_BASE environment variable is not set.
+    """
     if not os.getenv("OLLAMA_API_BASE"):
         raise ValueError("OLLAMA_API_BASE environment variable required")
 

--- a/examples/custom_reflection_prompt.py
+++ b/examples/custom_reflection_prompt.py
@@ -1,7 +1,8 @@
 """Example: Custom reflection prompt configuration.
 
 This example demonstrates how to customize the reflection prompt used during
-evolution to tailor the mutation strategy for your specific use case.
+evolution to tailor the mutation strategy for your specific use case. Uses
+``run_sync(evolve(...))`` for synchronous execution.
 
 The reflection prompt is the template sent to the reflection model to generate
 improved agent instructions. By customizing it, you can:
@@ -17,6 +18,16 @@ Prerequisites:
 
 Usage:
     python examples/custom_reflection_prompt.py
+
+Examples:
+    Run from the repository root:
+
+    ```bash
+    python examples/custom_reflection_prompt.py
+    ```
+
+See Also:
+    - :mod:`gepa_adk.api` — Public API entry points.
 """
 
 from __future__ import annotations
@@ -29,7 +40,7 @@ from google.adk.agents import LlmAgent
 from google.adk.models.lite_llm import LiteLlm
 from pydantic import BaseModel, Field
 
-from gepa_adk import EvolutionConfig, EvolutionResult, evolve_sync
+from gepa_adk import EvolutionConfig, EvolutionResult, evolve, run_sync
 from gepa_adk.utils import EncodingSafeProcessor
 
 # -----------------------------------------------------------------------------
@@ -80,8 +91,13 @@ class CriticOutput(BaseModel):
     """Structured output for critic evaluation.
 
     Attributes:
-        score: Quality score (0.0-1.0).
-        feedback: Detailed evaluation feedback.
+        score (float): Quality score (0.0-1.0).
+        feedback (str): Detailed evaluation feedback.
+
+    Examples:
+        ```python
+        output = CriticOutput(score=0.8, feedback="Good greeting")
+        ```
     """
 
     score: float = Field(
@@ -240,7 +256,7 @@ def run_with_custom_prompt(
     prompt_name: str,
     custom_prompt: str,
 ) -> EvolutionResult:
-    """Run evolution with a custom reflection prompt.
+    """Run evolution with a custom reflection prompt via ``run_sync(evolve(...))``.
 
     Args:
         agent: The agent to evolve.
@@ -271,7 +287,7 @@ def run_with_custom_prompt(
         instruction=agent.instruction,
     )
 
-    result = evolve_sync(fresh_agent, trainset, critic=critic, config=config)
+    result = run_sync(evolve(fresh_agent, trainset, critic=critic, config=config))
 
     logger.info(
         "evolution.complete",
@@ -285,7 +301,11 @@ def run_with_custom_prompt(
 
 
 def main() -> None:
-    """Run the custom reflection prompt examples."""
+    """Run the custom reflection prompt examples via ``run_sync(evolve(...))``.
+
+    Raises:
+        ValueError: If OLLAMA_API_BASE environment variable is not set.
+    """
     # Check for Ollama API base
     if not os.getenv("OLLAMA_API_BASE"):
         raise ValueError("OLLAMA_API_BASE environment variable required")
@@ -325,7 +345,7 @@ def main() -> None:
             instruction=agent.instruction,
         )
 
-        result = evolve_sync(fresh_agent, trainset, critic=critic, config=config)
+        result = run_sync(evolve(fresh_agent, trainset, critic=critic, config=config))
         results.append((prompt_name, result))
 
         print(f"Original score: {result.original_score:.3f}")

--- a/examples/schema_evolution_critic.py
+++ b/examples/schema_evolution_critic.py
@@ -3,7 +3,7 @@
 This example demonstrates evolving an agent's output_schema based on critic
 feedback. The summarizer agent starts with a minimal schema (just 'summary'),
 but the critic expects comprehensive analysis. GEPA evolves the schema to
-match expectations.
+match expectations. Uses ``ADKAdapter`` and ``AsyncGEPAEngine`` directly.
 
 **Unified Execution Path:**
 
@@ -30,6 +30,16 @@ Prerequisites:
 
 Usage:
     python examples/schema_evolution_critic.py
+
+Examples:
+    Run from the repository root:
+
+    ```bash
+    python examples/schema_evolution_critic.py
+    ```
+
+See Also:
+    - :mod:`gepa_adk.engine` — AsyncGEPAEngine for direct engine usage.
 """
 
 from __future__ import annotations
@@ -44,8 +54,7 @@ from google.adk.models.lite_llm import LiteLlm
 from pydantic import BaseModel, Field
 
 from gepa_adk import EvolutionConfig
-from gepa_adk.adapters import AgentExecutor, CriticScorer
-from gepa_adk.adapters.adk_adapter import ADKAdapter
+from gepa_adk.adapters import ADKAdapter, AgentExecutor, CriticScorer
 from gepa_adk.domain.models import Candidate, EvolutionResult
 from gepa_adk.engine import AsyncGEPAEngine
 from gepa_adk.utils import EncodingSafeProcessor
@@ -93,6 +102,11 @@ class MinimalSummary(BaseModel):
     This intentionally lacking schema will be evolved based on critic feedback.
     The summarizer doesn't know it needs more fields - the critic will guide
     the evolution toward a richer schema.
+
+    Examples:
+        ```python
+        output = MinimalSummary(summary="Article discusses AI trends.")
+        ```
     """
 
     summary: str = Field(description="Brief summary of the article")
@@ -104,6 +118,11 @@ class CriticOutput(BaseModel):
     The critic expects comprehensive analysis and will penalize outputs
     that lack key_points, sentiment, confidence, etc. - even though the
     generator's schema doesn't have these fields yet.
+
+    Examples:
+        ```python
+        output = CriticOutput(score=0.6, feedback="Missing key points")
+        ```
     """
 
     score: float = Field(
@@ -228,6 +247,14 @@ class SchemaProposal(BaseModel):
     By using an output_schema on the reflection agent, we ENFORCE that the
     LLM produces only a class definition without imports. This is more
     reliable than text-based instructions.
+
+    Examples:
+        ```python
+        proposal = SchemaProposal(
+            class_definition="class Output(BaseModel): ...",
+            reasoning="Added sentiment field per critic feedback",
+        )
+        ```
     """
 
     class_definition: str = Field(
@@ -290,6 +317,15 @@ class OutputSchemaOnlySelector:
     This selector ensures only the output_schema component is mutated,
     leaving the instruction unchanged. This focuses evolution entirely
     on schema structure.
+
+    Examples:
+        ```python
+        selector = OutputSchemaOnlySelector()
+        selected = await selector.select_components(
+            ["instruction", "output_schema"], 0, 0
+        )
+        # selected == ["output_schema"]
+        ```
     """
 
     async def select_components(
@@ -422,7 +458,11 @@ async def run_evolution(
 
 
 async def main() -> None:
-    """Run the schema evolution example."""
+    """Run the schema evolution example.
+
+    Raises:
+        ValueError: If OLLAMA_API_BASE environment variable is not set.
+    """
     if not os.getenv("OLLAMA_API_BASE"):
         raise ValueError("OLLAMA_API_BASE environment variable required")
 


### PR DESCRIPTION
User-facing docs and examples referenced pre-ADR-014 import paths and the
deprecated `evolve_sync()` API. This cleans up all public-facing content
for the 2.0 release while leaving historical ADRs and proposals untouched.

- Fix broken imports in 4 guides and 1 example (`adapters.adk_adapter`,
  `adapters.critic_scorer`, `engine.adk_reflection` → public re-exports)
- Migrate all `evolve_sync()` calls to `run_sync(evolve(...))` across 6
  guides, 2 reference pages, glossary, landing page, and 2 examples
- Rewrite `releasing.md` to document release-please automation (was manual)
- Expand README with capabilities, requirements, and 11 categorized examples
- Correct ADR-014 sub-package count (7→9) and re-export count (33→34)
- Fix 3 MkDocs cross-references pointing to old `adapters.critic_scorer` path

Test: `uv run pytest` — 2089 passed, all pre-commit hooks green

fix(docs): correct MkDocs cross-references to scoring sub-package

Three `[gepa_adk.adapters.critic_scorer.*]` cross-references updated to
`[gepa_adk.adapters.scoring.critic_scorer.*]` in critic-agents.md and
multi-agent.md.

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Import path corrections in guides (critic-agents, multi-agent, reflection-prompts, single-agent)
- `evolve_sync` → `run_sync(evolve(...))` migration completeness
- `releasing.md` full rewrite accuracy against actual release-please config

### Related
- ADR-014 (adapter reorganization)
- Story 2-6 (universal sync wrapper / API surface polish)