### PR TITLE
feat(scoring): add create_critic() preset factory with three MVP presets

### DIFF
--- a/_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md
+++ b/_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md
@@ -1,0 +1,232 @@
+# Story 3.1: Implement Critic Preset Factory
+
+Status: ready-for-dev
+
+## Story
+
+As a developer,
+I want to use pre-built critic agents by name,
+so that I can add structured evaluation without defining custom critic agents.
+
+## Acceptance Criteria
+
+1. `create_critic(name, *, model=None)` exists in `adapters/scoring/critic_scorer.py` and returns a configured `LlmAgent`
+2. Three MVP presets available: `"structured_output"`, `"accuracy"`, `"relevance"`
+3. Invalid preset names raise `ConfigurationError` with message listing valid presets (using existing `constraint` field for structured context)
+4. `create_critic` is re-exported via `gepa_adk.__init__` (added to `__all__`)
+5. `gepa_adk.critic_presets` dict maps preset name to human-readable description, also re-exported
+6. Four deterministic unit tests: one per preset (3) + invalid-name error test (1)
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Implement `create_critic()` factory and `critic_presets` dict (AC: 1, 2, 5)
+  - [ ] 1.1 Add `critic_presets` dict with ASI-aware descriptions:
+    - `"structured_output": "Scores output format/schema compliance with per-dimension diagnostics"`
+    - `"accuracy": "Scores factual correctness with error diagnosis and improvement guidance"`
+    - `"relevance": "Scores topical relevance with coverage analysis and focus guidance"`
+  - [ ] 1.2 Add three new instruction constants (see Dev Notes for full text):
+    - `STRUCTURED_OUTPUT_CRITIC_INSTRUCTION`
+    - `ACCURACY_CRITIC_INSTRUCTION`
+    - `RELEVANCE_CRITIC_INSTRUCTION`
+  - [ ] 1.3 Add `create_critic(name: str, *, model: str | None = None) -> LlmAgent` function
+  - [ ] 1.4 All three presets use `CriticOutput` schema (maximizes ASI for reflector — see GEPA Context)
+  - [ ] 1.5 Each preset returns `LlmAgent(name=f"{name}_critic", instruction=..., output_schema=CriticOutput, **model_kwargs)`
+  - [ ] 1.6 Model handling: use conditional kwargs — `model_kwargs = {"model": model} if model is not None else {}` (mirrors reflection agent precedent; lets ADK use its default when None)
+  - [ ] 1.7 Add `__all__` at file BOTTOM (file currently has none) — include `create_critic`, `critic_presets`, and the three new instruction constants alongside existing exports
+- [ ] Task 2: Wire exports (AC: 4, 5)
+  - [ ] 2.1 Re-export `create_critic`, `critic_presets`, and new instruction constants from `adapters/scoring/__init__.py`
+  - [ ] 2.2 Re-export from `adapters/__init__.py`
+  - [ ] 2.3 Re-export from `gepa_adk/__init__.py` and add to its `__all__`
+- [ ] Task 3: Error handling (AC: 3)
+  - [ ] 3.1 Invalid name raises `ConfigurationError` — use existing fields only (no `suggestion` field exists):
+    ```python
+    raise ConfigurationError(
+        f"Unknown critic preset '{name}'. Valid presets: {', '.join(critic_presets)}",
+        constraint=f"Must be one of: {', '.join(critic_presets)}",
+        value=name,
+        field="name",
+    )
+    ```
+  - [ ] 3.2 Use `from gepa_adk.domain.exceptions import ConfigurationError`
+- [ ] Task 4: Unit tests (AC: 6)
+  - [ ] 4.1 Create `tests/unit/adapters/scoring/` directory with `__init__.py` (does not exist yet)
+  - [ ] 4.2 Create `tests/unit/adapters/scoring/test_critic_preset_factory.py`
+  - [ ] 4.3 Set `pytestmark = pytest.mark.unit` at module level
+  - [ ] 4.4 `test_create_critic_structured_output_returns_llm_agent` — verify: `isinstance(agent, LlmAgent)`, `agent.name == "structured_output_critic"`, `agent.output_schema == CriticOutput`, `"dimension_scores" in agent.instruction.lower()`, `"actionable_guidance" in agent.instruction.lower()`
+  - [ ] 4.5 `test_create_critic_accuracy_returns_llm_agent` — same pattern; also assert `"factual" in agent.instruction.lower()`
+  - [ ] 4.6 `test_create_critic_relevance_returns_llm_agent` — same pattern; also assert `"relevant" in agent.instruction.lower()`
+  - [ ] 4.7 `test_create_critic_invalid_name_raises_configuration_error` — verify `ConfigurationError` raised, check `exc.constraint` contains valid preset names
+  - [ ] 4.8 `test_create_critic_reexported_from_package` — `from gepa_adk import create_critic, critic_presets; assert callable(create_critic); assert isinstance(critic_presets, dict)` (covers AC 4+5)
+- [ ] [TEA] Testing maturity: add model-override test verifying `create_critic("accuracy", model="some/model")` passes model through to `LlmAgent` (cross-cutting, optional)
+
+## Dev Notes
+
+### GEPA Context: Why Critic Presets Are ASI Generators
+
+The GEPA paper (arXiv:2507.19457, ICLR 2026 Oral) defines **Actionable Side Information (ASI)** as "the text-optimization analogue of a gradient." The reflector LLM reads ASI to diagnose *why* a candidate failed and proposes *targeted* fixes. Without rich ASI, GEPA degrades to blind mutation.
+
+Our `Scorer` protocol returns `tuple[float, dict[str, Any]]` — this IS the GEPA `(scalar, ASI)` primitive. The `CriticOutput` schema maps directly:
+- `score` -> scalar fitness metric
+- `feedback` -> text ASI (diagnostic explanation)
+- `dimension_scores` -> multi-objective ASI (enables Pareto frontier selection)
+- `actionable_guidance` -> structured ASI (concrete fix suggestions for the reflector)
+
+**All presets use `CriticOutput`** (not `SimpleCriticOutput`) to maximize ASI quality. This overrides Architecture Decision 3 which originally specified `SimpleCriticOutput` for `"structured_output"` — the ASI quality benefit outweighs the minimal schema overhead. Users who want minimal feedback can still construct their own `LlmAgent` with `SimpleCriticOutput` directly.
+
+### Architecture Compliance
+
+- **Layer**: `adapters/` (uses external lib `google.adk.agents.LlmAgent`)
+- **Pattern**: Factory function, NOT registry (MVP). Follow existing `create_component_selector()` pattern in `adapters/selection/component_selector.py`
+- **Structural subtyping**: `create_critic` returns `LlmAgent` directly — no Protocol needed for the factory itself. The returned agent is consumed by `CriticScorer` which already satisfies `Scorer` Protocol
+- **Boundary enforcement**: Only `adapters/` may import `google.adk` — this is already in `adapters/scoring/`
+
+### Existing Code to Reuse (DO NOT REINVENT)
+
+- `CriticOutput` schema — already in `critic_scorer.py` (score, feedback, dimension_scores, actionable_guidance)
+- `SIMPLE_CRITIC_INSTRUCTION` and `ADVANCED_CRITIC_INSTRUCTION` — remain untouched for custom critic users
+- `ConfigurationError` — already in `domain/exceptions.py`, accepts keyword-only: `field`, `value`, `constraint` (NO `suggestion` field)
+- `LlmAgent` import — already used in `critic_scorer.py`: `from google.adk.agents import LlmAgent`
+- `normalize_feedback()` — already handles `CriticOutput` fields and passes them as trial metadata (the ASI pipeline)
+
+### Implementation Reference
+
+Model handling — use conditional kwargs (mirrors reflection agent pattern where `model: str` is required positional):
+```python
+def create_critic(name: str, *, model: str | None = None) -> LlmAgent:
+    model_kwargs: dict[str, Any] = {}
+    if model is not None:
+        model_kwargs["model"] = model
+
+    presets: dict[str, Callable[[], LlmAgent]] = {
+        "structured_output": lambda: LlmAgent(
+            name="structured_output_critic",
+            instruction=STRUCTURED_OUTPUT_CRITIC_INSTRUCTION,
+            output_schema=CriticOutput,
+            **model_kwargs,
+        ),
+        # ... accuracy, relevance follow same pattern
+    }
+
+    if name not in presets:
+        raise ConfigurationError(...)
+    return presets[name]()
+```
+
+Naming convention: `{preset_name}_critic` (follows `{purpose}_{role}` pattern from reflection agents: `text_reflector`, `schema_reflector`).
+
+### Preset Instruction Constants
+
+Three NEW constants to add (existing `SIMPLE_CRITIC_INSTRUCTION` and `ADVANCED_CRITIC_INSTRUCTION` remain untouched):
+
+**`STRUCTURED_OUTPUT_CRITIC_INSTRUCTION`**:
+```
+Evaluate whether the output follows the expected structure and format.
+
+Score from 0.0 (completely malformed) to 1.0 (perfectly structured).
+
+In your feedback, diagnose specific structural issues: missing fields,
+wrong types, malformed JSON, schema violations. Quote the problematic
+sections and explain what the correct structure should be.
+
+Provide dimension_scores for: schema_compliance, field_completeness,
+type_correctness, format_consistency.
+
+In actionable_guidance, give concrete instructions for fixing each
+structural issue found. The guidance should be specific enough that
+a prompt editor can adjust the system prompt to prevent these issues.
+```
+
+**`ACCURACY_CRITIC_INSTRUCTION`**:
+```
+Evaluate the factual accuracy and correctness of the output relative
+to the input and any expected answer.
+
+Score from 0.0 (completely wrong) to 1.0 (perfectly accurate).
+
+In your feedback, identify specific factual errors, logical flaws,
+or reasoning mistakes. Quote incorrect passages and explain what
+the correct answer or reasoning should be.
+
+Provide dimension_scores for: factual_correctness, reasoning_quality,
+completeness, consistency.
+
+In actionable_guidance, explain what knowledge or reasoning patterns
+the system prompt should emphasize to prevent these accuracy issues.
+```
+
+**`RELEVANCE_CRITIC_INSTRUCTION`**:
+```
+Evaluate whether the output is relevant to the input query and
+addresses what was actually asked.
+
+Score from 0.0 (completely off-topic) to 1.0 (perfectly relevant).
+
+In your feedback, identify which aspects of the query were addressed,
+which were missed, and any tangential content that dilutes relevance.
+Quote specific passages that are on-topic or off-topic.
+
+Provide dimension_scores for: query_alignment, topic_coverage,
+completeness, focus.
+
+In actionable_guidance, explain how the system prompt should be
+adjusted to improve topical focus and query coverage.
+```
+
+### Exception Pattern
+
+```python
+raise ConfigurationError(
+    f"Unknown critic preset '{name}'. Valid presets: {', '.join(critic_presets)}",
+    constraint=f"Must be one of: {', '.join(critic_presets)}",
+    value=name,
+    field="name",
+)
+```
+No `cause=` or `from e` needed here — this is a direct raise, not wrapping another exception.
+
+### Growth Phase Vision (Out of Scope — Documented for Future Stories)
+
+The MVP delivers three **content-focused** presets that evaluate agent *output quality*. The factory API (`create_critic()`) is designed to grow with trajectory-dependent presets that evaluate agent *behavior*:
+
+- **`"tool_use"`** — Grades tool selection, argument quality, call sequencing, efficiency. Enables evolving instructions for agents using MCP servers (Playwright, search APIs, databases). Dimensions: `tool_selection_accuracy`, `argument_quality`, `call_sequencing`, `efficiency`, `error_handling`.
+- **`"safety"`** — Grades policy compliance, content safety, data leakage, boundary adherence. Content evaluation works now; action-level safety needs trajectory.
+- **`"efficiency"`** — Grades step count, token cost, redundancy, directness. Requires trajectory metadata.
+
+**Pipeline change required**: `CriticScorer._format_critic_input()` must accept optional trajectory data for action-focused presets. Same factory API surface — `create_critic("tool_use")` — no breaking changes.
+
+**Innovation context**: gepa-adk is the only GEPA implementation providing structured ASI schemas and preset critics. GEPA-AI and DSPy both use unstructured feedback. Our `CriticOutput` schema formalizes the "gradient" that GEPA conceptualized but never structured.
+
+Candidate stories documented in `epics.md` (Stories 3.4, 3.5, 3.6) and architecture rationale in `architecture.md` Decision 3 Growth phase.
+
+### Documentation Impact
+
+- No documentation impact (confirmed). This is a new function added to the public API — the v2.0.0 docs were just released and this will be documented in a future Epic 8 story (8-2-documentation-updates).
+
+### Project Structure Notes
+
+- Implementation file: `src/gepa_adk/adapters/scoring/critic_scorer.py` (add to existing file)
+- Test file: `tests/unit/adapters/scoring/test_critic_preset_factory.py` (new file, new directory)
+- Export chain: `critic_scorer.py` -> `scoring/__init__.py` -> `adapters/__init__.py` -> `gepa_adk/__init__.py`
+- `tests/unit/adapters/scoring/` does NOT exist yet — create it with `__init__.py`
+- `critic_scorer.py` currently has NO `__all__` — add one at file BOTTOM
+
+### References
+
+- [Source: GEPA paper arXiv:2507.19457 — ASI concept, feedback primitives, Pareto frontier]
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 3, Story 3.1]
+- [Source: _bmad-output/planning-artifacts/architecture.md#Decision 3 - Critic Presets (overridden: all presets use CriticOutput)]
+- [Source: src/gepa_adk/adapters/scoring/critic_scorer.py — CriticScorer, CriticOutput schema, instructions, normalize_feedback]
+- [Source: src/gepa_adk/adapters/selection/component_selector.py — factory pattern reference]
+- [Source: src/gepa_adk/adapters/agents/reflection_agents.py — LlmAgent factory and model-handling precedent]
+- [Source: src/gepa_adk/domain/exceptions.py — ConfigurationError (field, value, constraint only)]
+- [Source: _bmad-output/project-context.md — architecture rules, exception patterns]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md
+++ b/_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md
@@ -1,6 +1,6 @@
 # Story 3.1: Implement Critic Preset Factory
 
-Status: review
+Status: done
 
 ## Story
 
@@ -265,3 +265,4 @@ None — clean implementation, no debugging needed.
 
 ## Change Log
 - 2026-03-07: Implemented critic preset factory with 3 presets, full export chain, and 7 unit tests
+- 2026-03-07: Code review — fixed stale docstring and wrong constructor example in scoring/__init__.py (M1, M2). Deferred M3 (parallel dicts tech debt, already documented). Skipped L1/L2 (implicitly covered / intentional design). Status → done.

--- a/_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md
+++ b/_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md
@@ -1,6 +1,6 @@
 # Story 3.1: Implement Critic Preset Factory
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -19,26 +19,26 @@ so that I can add structured evaluation without defining custom critic agents.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Implement `create_critic()` factory and `critic_presets` dict (AC: 1, 2, 5)
-  - [ ] 1.1 Add `critic_presets` dict with ASI-aware descriptions:
+- [x] Task 1: Implement `create_critic()` factory and `critic_presets` dict (AC: 1, 2, 5)
+  - [x] 1.1 Add `critic_presets` dict with ASI-aware descriptions:
     - `"structured_output": "Scores output format/schema compliance with per-dimension diagnostics"`
     - `"accuracy": "Scores factual correctness with error diagnosis and improvement guidance"`
     - `"relevance": "Scores topical relevance with coverage analysis and focus guidance"`
-  - [ ] 1.2 Add three new instruction constants (see Dev Notes for full text):
+  - [x] 1.2 Add three new instruction constants (see Dev Notes for full text):
     - `STRUCTURED_OUTPUT_CRITIC_INSTRUCTION`
     - `ACCURACY_CRITIC_INSTRUCTION`
     - `RELEVANCE_CRITIC_INSTRUCTION`
-  - [ ] 1.3 Add `create_critic(name: str, *, model: str | None = None) -> LlmAgent` function
-  - [ ] 1.4 All three presets use `CriticOutput` schema (maximizes ASI for reflector — see GEPA Context)
-  - [ ] 1.5 Each preset returns `LlmAgent(name=f"{name}_critic", instruction=..., output_schema=CriticOutput, **model_kwargs)`
-  - [ ] 1.6 Model handling: use conditional kwargs — `model_kwargs = {"model": model} if model is not None else {}` (mirrors reflection agent precedent; lets ADK use its default when None)
-  - [ ] 1.7 Add `__all__` at file BOTTOM (file currently has none) — include `create_critic`, `critic_presets`, and the three new instruction constants alongside existing exports
-- [ ] Task 2: Wire exports (AC: 4, 5)
-  - [ ] 2.1 Re-export `create_critic`, `critic_presets`, and new instruction constants from `adapters/scoring/__init__.py`
-  - [ ] 2.2 Re-export from `adapters/__init__.py`
-  - [ ] 2.3 Re-export from `gepa_adk/__init__.py` and add to its `__all__`
-- [ ] Task 3: Error handling (AC: 3)
-  - [ ] 3.1 Invalid name raises `ConfigurationError` — use existing fields only (no `suggestion` field exists):
+  - [x] 1.3 Add `create_critic(name: str, *, model: str | None = None) -> LlmAgent` function
+  - [x] 1.4 All three presets use `CriticOutput` schema (maximizes ASI for reflector — see GEPA Context)
+  - [x] 1.5 Each preset returns `LlmAgent(name=f"{name}_critic", instruction=..., output_schema=CriticOutput, **model_kwargs)`
+  - [x] 1.6 Model handling: use conditional kwargs — `model_kwargs = {"model": model} if model is not None else {}` (mirrors reflection agent precedent; lets ADK use its default when None)
+  - [x] 1.7 Add `__all__` at file BOTTOM (file currently has none) — include `create_critic`, `critic_presets`, and the three new instruction constants alongside existing exports
+- [x] Task 2: Wire exports (AC: 4, 5)
+  - [x] 2.1 Re-export `create_critic`, `critic_presets`, and new instruction constants from `adapters/scoring/__init__.py`
+  - [x] 2.2 Re-export from `adapters/__init__.py`
+  - [x] 2.3 Re-export from `gepa_adk/__init__.py` and add to its `__all__`
+- [x] Task 3: Error handling (AC: 3)
+  - [x] 3.1 Invalid name raises `ConfigurationError` — use existing fields only (no `suggestion` field exists):
     ```python
     raise ConfigurationError(
         f"Unknown critic preset '{name}'. Valid presets: {', '.join(critic_presets)}",
@@ -47,17 +47,17 @@ so that I can add structured evaluation without defining custom critic agents.
         field="name",
     )
     ```
-  - [ ] 3.2 Use `from gepa_adk.domain.exceptions import ConfigurationError`
-- [ ] Task 4: Unit tests (AC: 6)
-  - [ ] 4.1 Create `tests/unit/adapters/scoring/` directory with `__init__.py` (does not exist yet)
-  - [ ] 4.2 Create `tests/unit/adapters/scoring/test_critic_preset_factory.py`
-  - [ ] 4.3 Set `pytestmark = pytest.mark.unit` at module level
-  - [ ] 4.4 `test_create_critic_structured_output_returns_llm_agent` — verify: `isinstance(agent, LlmAgent)`, `agent.name == "structured_output_critic"`, `agent.output_schema == CriticOutput`, `"dimension_scores" in agent.instruction.lower()`, `"actionable_guidance" in agent.instruction.lower()`
-  - [ ] 4.5 `test_create_critic_accuracy_returns_llm_agent` — same pattern; also assert `"factual" in agent.instruction.lower()`
-  - [ ] 4.6 `test_create_critic_relevance_returns_llm_agent` — same pattern; also assert `"relevant" in agent.instruction.lower()`
-  - [ ] 4.7 `test_create_critic_invalid_name_raises_configuration_error` — verify `ConfigurationError` raised, check `exc.constraint` contains valid preset names
-  - [ ] 4.8 `test_create_critic_reexported_from_package` — `from gepa_adk import create_critic, critic_presets; assert callable(create_critic); assert isinstance(critic_presets, dict)` (covers AC 4+5)
-- [ ] [TEA] Testing maturity: add model-override test verifying `create_critic("accuracy", model="some/model")` passes model through to `LlmAgent` (cross-cutting, optional)
+  - [x] 3.2 Use `from gepa_adk.domain.exceptions import ConfigurationError`
+- [x] Task 4: Unit tests (AC: 6)
+  - [x] 4.1 Create `tests/unit/adapters/scoring/` directory with `__init__.py` (does not exist yet)
+  - [x] 4.2 Create `tests/unit/adapters/scoring/test_critic_preset_factory.py`
+  - [x] 4.3 Set `pytestmark = pytest.mark.unit` at module level
+  - [x] 4.4 `test_create_critic_structured_output_returns_llm_agent` — verify: `isinstance(agent, LlmAgent)`, `agent.name == "structured_output_critic"`, `agent.output_schema == CriticOutput`, `"dimension_scores" in agent.instruction.lower()`, `"actionable_guidance" in agent.instruction.lower()`
+  - [x] 4.5 `test_create_critic_accuracy_returns_llm_agent` — same pattern; also assert `"factual" in agent.instruction.lower()`
+  - [x] 4.6 `test_create_critic_relevance_returns_llm_agent` — same pattern; also assert `"relevant" in agent.instruction.lower()`
+  - [x] 4.7 `test_create_critic_invalid_name_raises_configuration_error` — verify `ConfigurationError` raised, check `exc.constraint` contains valid preset names
+  - [x] 4.8 `test_create_critic_reexported_from_package` — `from gepa_adk import create_critic, critic_presets; assert callable(create_critic); assert isinstance(critic_presets, dict)` (covers AC 4+5)
+- [x] [TEA] Testing maturity: add model-override test verifying `create_critic("accuracy", model="some/model")` passes model through to `LlmAgent` (cross-cutting, optional)
 
 ## Dev Notes
 
@@ -221,12 +221,47 @@ Candidate stories documented in `epics.md` (Stories 3.4, 3.5, 3.6) and architect
 - [Source: src/gepa_adk/domain/exceptions.py — ConfigurationError (field, value, constraint only)]
 - [Source: _bmad-output/project-context.md — architecture rules, exception patterns]
 
+## AC-to-Test Mapping
+
+| AC | Test | Status |
+|----|------|--------|
+| AC1: `create_critic()` exists and returns `LlmAgent` | `test_create_critic_structured_output_returns_llm_agent` | PASS |
+| AC2: Three MVP presets available | `test_critic_presets_is_dict_with_three_entries` | PASS |
+| AC3: Invalid preset raises `ConfigurationError` | `test_create_critic_invalid_name_raises_configuration_error` | PASS |
+| AC4: Re-exported via `gepa_adk.__init__` | `test_create_critic_reexported_from_package` | PASS |
+| AC5: `critic_presets` dict re-exported | `test_create_critic_reexported_from_package` | PASS |
+| AC6: Four+ deterministic unit tests | All 7 tests in `test_critic_preset_factory.py` | PASS |
+
 ## Dev Agent Record
 
 ### Agent Model Used
+Claude Opus 4.6
 
 ### Debug Log References
+None — clean implementation, no debugging needed.
 
 ### Completion Notes List
+- Implemented `create_critic()` factory function and `critic_presets` dict in `critic_scorer.py`
+- Added 3 preset instruction constants: `STRUCTURED_OUTPUT_CRITIC_INSTRUCTION`, `ACCURACY_CRITIC_INSTRUCTION`, `RELEVANCE_CRITIC_INSTRUCTION`
+- All presets use `CriticOutput` schema (maximizing ASI quality for reflector)
+- Model passthrough uses conditional kwargs pattern (mirrors reflection agent precedent)
+- Invalid preset raises `ConfigurationError` with `constraint` field listing valid presets
+- Added `__all__` at file bottom with all exports
+- Wired exports through full chain: `critic_scorer.py` -> `scoring/__init__.py` -> `adapters/__init__.py` -> `gepa_adk/__init__.py`
+- Updated existing `test_adapter_reexports.py` to include 5 new symbols
+- Created 7 unit tests (3 per-preset + invalid name + model override + presets dict + re-export)
+- Full suite: 2101 passed, 0 failures
 
 ### File List
+- `src/gepa_adk/adapters/scoring/critic_scorer.py` (modified — factory, presets, instructions, `__all__`)
+- `src/gepa_adk/adapters/scoring/__init__.py` (modified — new re-exports)
+- `src/gepa_adk/adapters/__init__.py` (modified — new re-exports)
+- `src/gepa_adk/__init__.py` (modified — new re-exports and `__all__` entries)
+- `tests/unit/adapters/scoring/__init__.py` (new)
+- `tests/unit/adapters/scoring/test_critic_preset_factory.py` (new — 7 tests)
+- `tests/unit/adapters/test_adapter_reexports.py` (modified — 5 new re-export cases)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified — status update)
+- `_bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md` (modified — task tracking)
+
+## Change Log
+- 2026-03-07: Implemented critic preset factory with 3 presets, full export chain, and 7 unit tests

--- a/_bmad-output/implementation-artifacts/epic-2-retro-2026-03-06.md
+++ b/_bmad-output/implementation-artifacts/epic-2-retro-2026-03-06.md
@@ -1,0 +1,132 @@
+# Epic 2 Retrospective: Single-Agent Evolution
+
+**Date:** 2026-03-06
+**Facilitator:** Bob (Scrum Master)
+**Participants:** Alice (Product Owner), Charlie (Senior Dev), Dana (QA Engineer), Elena (Junior Dev), Alberto-Codes (Project Lead)
+
+---
+
+## Epic Summary
+
+- **Epic:** 2 — Single-Agent Evolution
+- **Stories Completed:** 9/9 (100%)
+- **Test Count Growth:** ~1856 → 2089 (+233 tests)
+- **Coverage:** ~89% (maintained >85% floor)
+- **Production Incidents:** 0
+- **Regressions:** 0
+- **Breaking Changes:** 1 (keyword-only API signatures → v2.0.0)
+- **Release:** v2.0.0 (PR #278)
+
+### Stories Delivered
+
+| Story | Title | Key Contribution |
+|-------|-------|-----------------|
+| 2-1 | StopReason, Schema Version | StopReason enum, schema versioning |
+| 2-2 | Result Serialization | `to_dict()` / `from_dict()` stdlib-only |
+| 2-3 | Display Enhancements | `__repr__`, `show_diff()`, `_repr_html_()` |
+| 2-4 | Graceful Interrupt | Ctrl+C returns partial results |
+| 2-5 | Pre-Flight Validation | Sync validators, critic/config/component checks |
+| 2-6 | Sync Wrapper & API Polish | `run_sync()`, keyword-only params (BREAKING) |
+| 2-7 | Seed-Based Determinism | Central RNG shared across components |
+| 2-8 | Mutation Rationale Capture | `reflection_reasoning` from thought parts |
+| 2-9 | Credential Redaction Defaults | DEFAULT_SENSITIVE_KEYS expanded |
+
+---
+
+## Previous Retro Follow-Through (Epic 1A/1B)
+
+| Commitment | Status | Evidence |
+|-----------|--------|----------|
+| Continue "Previous Story Learnings" sections | Done | Applied in all 9 stories |
+| Discovery-first philosophy | Done | Consistently grepped before adding code |
+| Quality infrastructure compounding | Done | Zero regressions, 233 new tests |
+| Multi-layer review process | Done | Caught real issues in 5/9 stories |
+
+**Result:** 4/4 commitments honored. Risk predictions from 1A/1B retro were accurate — Stories 2.4, 2.6, 2.7 (flagged Medium risk) had the most complex implementation challenges.
+
+---
+
+## What Went Well
+
+- **Clean API surface** — `run_sync(evolve(...))` and keyword-only params make the library faster and more beautiful to use. User confirmed: less code, more insight.
+- **100% delivery with zero regressions** — 9 stories, 233 new tests, ~89% coverage maintained throughout.
+- **Backward compatibility discipline** — 8/9 stories added optional fields with `None` defaults and no schema bumps. Clean pattern applied consistently.
+- **Breaking change handled properly** — Keyword-only separator in 2.6 required v2.0.0 bump. Managed cleanly with semver.
+- **Quality pipeline compounding** — Pre-commit hooks, ruff, docvet, ty, pytest gates caught issues early and consistently. Each story benefited from gates established in prior stories.
+- **Code review catching real issues** — Placeholder tests, weak assertions, missing re-exports, stale docstrings caught in 5/9 stories.
+
+### Key Design Breakthroughs
+
+1. **Sync validators as network-call guards (2.5)** — Making validators `def` (not `async def`) so the type checker catches accidental network calls at compile time.
+2. **Central RNG pattern (2.7)** — Single `Random(seed)` instance shared across all stochastic components for cross-component determinism.
+3. **Post-hoc reasoning extraction (2.8)** — Reasoning already available in `captured_events` thought parts; no prompt changes needed.
+
+---
+
+## Challenges
+
+- **Breaking change timing** — The v2.0.0 bump from keyword-only params in 2.6 wasn't anticipated at sprint planning. Acceptable for brownfield inheritance — breaking changes are inevitable, and this was a clean boundary.
+- **Placeholder tests in first pass** — Code review caught shallow tests in Stories 2.2 and 2.7. TEA test-review workflow handles this systematically; no process change needed.
+- **Python runtime-version sensitivity** — `asyncio.CancelledError` changed from `Exception` to `BaseException` in Python 3.12. Integration tests cover this, but it requires awareness.
+
+---
+
+## Key Insights
+
+1. **The quality pipeline compounds** — Each gate makes the next story safer. 233 new tests with zero regressions is the compound effect in action.
+2. **"Previous Story Learnings" remains the most impactful process improvement** — Knowledge chains across stories prevent repeated mistakes and accelerate delivery.
+3. **Brownfield projects will cross breaking-change boundaries** — Handle them cleanly with semver rather than avoiding them.
+4. **When the API feels faster and more beautiful, the abstractions are right** — User experience is the ultimate validation of design decisions.
+
+---
+
+## Technical Debt
+
+All items are optional TEA items — none are blocking:
+
+| Item | Priority | Owner |
+|------|----------|-------|
+| Split `test_models.py` (2528 lines) into per-model files | Low | Dev team (opportunistic) |
+| Complete migration to factory fixtures | Low | Dev team (opportunistic) |
+| Boundary/adversarial tests for display utilities | Low | Dev team (opportunistic) |
+| StopReason enum exhaustiveness boundary test | Low | Dev team (opportunistic) |
+
+---
+
+## Action Items
+
+### Process Continuations
+
+1. **Continue "Previous Story Learnings" sections** in all future stories
+   - Owner: SM (Bob)
+   - Success criteria: Every story file includes learnings from prior stories
+
+2. **Continue TEA test-review workflow** for catching placeholder/weak tests
+   - Owner: Dev team
+   - Success criteria: test-review.md generated and items addressed before merge
+
+### Team Agreements
+
+- Backward compatibility by default; flag potential breaking changes at story creation time
+- Zero-regression standard maintained as baseline expectation
+
+---
+
+## Epic 3 Readiness
+
+**Status:** Ready — no preparation needed
+
+- All dependencies on Epic 2 complete and stable
+- Critic validation (2.5), Protocol infrastructure (1B) all in place
+- Contract test three-class template pattern well-established
+- Team confident and experienced with patterns
+
+**No blockers. No critical path items. No prep sprint required.**
+
+---
+
+## Next Steps
+
+1. Mark Epic 2 as `done` in sprint-status
+2. Begin Epic 3 — create first story (`3-1-implement-critic-preset-factory`)
+3. Review action items in next standup

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -66,7 +66,7 @@ development_status:
   epic-1b-retrospective: done
 
   # ── Epic 2: Single-Agent Evolution ──
-  epic-2: in-progress
+  epic-2: done
   2-1-add-stop-reason-schema-version-and-stop-reason-to-results: done
   2-2-result-serialization: done
   2-3-evolution-result-display-enhancements: done
@@ -76,11 +76,11 @@ development_status:
   2-7-seed-based-determinism: done
   2-8-mutation-rationale-capture: done
   2-9-credential-redaction-defaults: done
-  epic-2-retrospective: optional
+  epic-2-retrospective: done
 
   # ── Epic 3: Evolution Control & Extensibility ──
-  epic-3: backlog
-  3-1-implement-critic-preset-factory: backlog
+  epic-3: in-progress
+  3-1-implement-critic-preset-factory: ready-for-dev
   3-2-fill-contract-test-gaps: backlog
   3-3-extension-point-documentation: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -80,7 +80,7 @@ development_status:
 
   # ── Epic 3: Evolution Control & Extensibility ──
   epic-3: in-progress
-  3-1-implement-critic-preset-factory: ready-for-dev
+  3-1-implement-critic-preset-factory: review
   3-2-fill-contract-test-gaps: backlog
   3-3-extension-point-documentation: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -80,7 +80,7 @@ development_status:
 
   # ── Epic 3: Evolution Control & Extensibility ──
   epic-3: in-progress
-  3-1-implement-critic-preset-factory: review
+  3-1-implement-critic-preset-factory: done
   3-2-fill-contract-test-gaps: backlog
   3-3-extension-point-documentation: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -387,9 +387,21 @@ If `model` is None, uses the default reflection model. Invalid name raises `Conf
 
 | Name | Schema | Instruction | Use Case |
 |------|--------|------------|----------|
-| `"structured_output"` | `SimpleCriticOutput` | `SIMPLE_CRITIC_INSTRUCTION` | Score output structure quality |
-| `"accuracy"` | `CriticOutput` | `ADVANCED_CRITIC_INSTRUCTION` | Score output correctness with detailed feedback |
-| `"relevance"` | `CriticOutput` | Relevance-focused instruction | Score output relevance to input |
+| `"structured_output"` | `CriticOutput` | `STRUCTURED_OUTPUT_CRITIC_INSTRUCTION` | Score output structure with per-dimension diagnostics |
+| `"accuracy"` | `CriticOutput` | `ACCURACY_CRITIC_INSTRUCTION` | Score factual correctness with error diagnosis |
+| `"relevance"` | `CriticOutput` | `RELEVANCE_CRITIC_INSTRUCTION` | Score topical relevance with coverage analysis |
+
+> **Amendment (2026-03-06):** All presets use `CriticOutput` (not `SimpleCriticOutput` for structured_output). Each preset has a dedicated ASI-optimized instruction constant requesting `dimension_scores` and `actionable_guidance`. Rationale: GEPA paper (arXiv:2507.19457) defines Actionable Side Information as "the text-optimization analogue of a gradient." `CriticOutput` fields map directly to GEPA's ASI contract — `feedback` = diagnostic text, `dimension_scores` = multi-objective Pareto input, `actionable_guidance` = targeted reflector input. Maximizing ASI quality improves evolution outcomes. gepa-adk is the only GEPA implementation providing structured ASI schemas and preset critics.
+
+**Growth phase presets (trajectory-dependent):**
+
+| Name | Schema | Evaluation Surface | Pipeline Requirement |
+|------|--------|--------------------|---------------------|
+| `"tool_use"` | `CriticOutput` | Action trajectory (tool selection, arguments, sequencing, efficiency) | Requires trajectory data in `CriticScorer._format_critic_input()` |
+| `"safety"` | `CriticOutput` | Content + actions (policy compliance, data leakage, boundary adherence) | Content works now; action evaluation needs trajectory |
+| `"efficiency"` | `CriticOutput` | Action trajectory (step count, token cost, redundancy, directness) | Requires step count and token usage in critic input |
+
+Growth phase presets require a pipeline change: `CriticScorer._format_critic_input()` must accept optional trajectory data so the critic can evaluate the agent's *behavior*, not just its *output*. This enables evolving agent instructions for better tool-use strategy (e.g., an agent using Playwright MCP, search APIs, or database tools).
 
 **Location:** `adapters/scoring/critic_scorer.py` (post-reorganization), re-exported via `gepa_adk.__init__`.
 

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -405,6 +405,8 @@ Growth phase presets require a pipeline change: `CriticScorer._format_critic_inp
 
 **Location:** `adapters/scoring/critic_scorer.py` (post-reorganization), re-exported via `gepa_adk.__init__`.
 
+> **Tech Debt (2026-03-07, Story 3.1 implementation review):** The MVP uses two parallel dicts keyed by preset name: `critic_presets` (name → description) and `_PRESET_INSTRUCTIONS` (name → instruction text). Adding a preset to one but not the other is a silent bug. When Growth phase presets are added (Stories 3.4-3.6), consolidate into a single data structure (e.g., `NamedTuple` or `dataclass` mapping name → description + instruction). Acceptable for 3 entries; becomes a maintenance risk at 6+.
+
 **Test matrix:** Three deterministic tests — one per preset name — plus invalid-name error test. No LLM calls required.
 
 **Affects:** Public API (`evolve(critic="structured_output")`), UX progressive disclosure

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -747,6 +747,8 @@ So that I can evolve agent instructions for better tool-use strategy (e.g., Play
 
 *Requires pipeline change: `CriticScorer._format_critic_input()` must accept optional trajectory data. Dimensions: tool_selection_accuracy, argument_quality, call_sequencing, efficiency, error_handling. Enables evolving action strategy, not just content quality. See GEPA ASI analysis in Story 3.1 Dev Notes.*
 
+*Tech debt prerequisite: Before adding the 4th preset, consolidate `critic_presets` and `_PRESET_INSTRUCTIONS` parallel dicts into a single data structure (e.g., NamedTuple mapping name → description + instruction). See Architecture Decision 3 tech debt note. Acceptable at 3 entries; becomes a maintenance risk at 6+.*
+
 ### [CANDIDATE] Story 3.5: Safety Critic Preset
 
 As a developer,

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -739,6 +739,30 @@ So that the protocol coverage CI check (from Story 1B.1) passes and new implemen
 **And** `tests/contracts/test_video_blob_service_protocol.py` exists with minimum 4 tests: isinstance check, method signature verification, happy path, error contract
 **And** `scripts/check_protocol_coverage.py` (from Story 1B.1) passes with zero missing Protocols
 
+### [CANDIDATE] Story 3.4: Tool-Use Critic Preset
+
+As a developer,
+I want a `create_critic("tool_use")` preset that evaluates agent tool-calling behavior,
+So that I can evolve agent instructions for better tool-use strategy (e.g., Playwright MCP, search APIs, database tools).
+
+*Requires pipeline change: `CriticScorer._format_critic_input()` must accept optional trajectory data. Dimensions: tool_selection_accuracy, argument_quality, call_sequencing, efficiency, error_handling. Enables evolving action strategy, not just content quality. See GEPA ASI analysis in Story 3.1 Dev Notes.*
+
+### [CANDIDATE] Story 3.5: Safety Critic Preset
+
+As a developer,
+I want a `create_critic("safety")` preset that evaluates agent output and actions for policy violations,
+So that I can evolve agent instructions to produce safer, policy-compliant behavior.
+
+*Content evaluation works with current pipeline. Action-level safety evaluation (tool misuse, boundary violations) requires trajectory data. Dimensions: policy_compliance, content_safety, data_leakage, boundary_adherence.*
+
+### [CANDIDATE] Story 3.6: Efficiency Critic Preset
+
+As a developer,
+I want a `create_critic("efficiency")` preset that evaluates whether an agent takes the optimal path,
+So that I can evolve agent instructions to minimize unnecessary steps and token usage.
+
+*Requires trajectory data with step counts and token usage. Dimensions: step_count, token_cost, redundancy, directness. Maps to ICLR 2026 agent evaluation taxonomy efficiency metrics.*
+
 ### Story 3.3: Extension Point Documentation
 
 As a contributor,
@@ -851,3 +875,6 @@ So that I can adopt new capabilities without reading source code.
 **And** `examples/` directory contains at minimum: `basic_evolution.py`, `multi_agent_evolution.py`, `custom_scorer.py`, `critic_presets.py`
 **And** examples are syntax-checked in CI (import validation, no runtime errors with mock fixtures)
 **And** Common Errors section added to getting-started guide with top 5 developer errors and their solutions
+**And** `critic-agents.md` includes a "Why Structured Feedback Matters" section explaining the GEPA ASI connection — how `CriticOutput` fields (`feedback`, `dimension_scores`, `actionable_guidance`) map to Actionable Side Information, how `dimension_scores` feeds Pareto frontier selection, and how `actionable_guidance` feeds the reflector for targeted mutations. Includes `create_critic()` quick-start after Story 3.1.
+**And** `gepa-fundamentals.md` Feedback section upgraded to show structured feedback (`CriticOutput` fields) and the ASI → reflection → mutation pipeline, connecting `dimension_scores` to the existing Pareto frontier diagram
+**And** documentation calls out gepa-adk's differentiation: the only GEPA implementation providing structured ASI schemas and preset critic agents (vs unstructured feedback in GEPA-AI and DSPy)

--- a/_bmad-output/test-artifacts/test-review.md
+++ b/_bmad-output/test-artifacts/test-review.md
@@ -1,7 +1,7 @@
 ---
 stepsCompleted: ['step-01-load-context', 'step-02-discover-tests', 'step-03-quality-criteria', 'step-04-score-calculation', 'step-05-report-generation']
 lastStep: 'step-05-report-generation'
-lastSaved: '2026-03-06'
+lastSaved: '2026-03-07'
 workflowType: 'testarch-test-review'
 inputDocuments:
   - '_bmad/tea/testarch/knowledge/test-quality.md'
@@ -16,8 +16,8 @@ inputDocuments:
 
 # Test Quality Review: Full Suite
 
-**Quality Score**: 82/100 (A - Good)
-**Review Date**: 2026-03-06
+**Quality Score**: 80/100 (A - Good)
+**Review Date**: 2026-03-07
 **Review Scope**: suite (all tests)
 **Reviewer**: TEA Agent
 
@@ -34,24 +34,25 @@ Coverage mapping and coverage gates are out of scope here. Use `trace` for cover
 
 ### Key Strengths
 
-- 2089 tests pass in 2.75s - exceptionally fast, fully deterministic suite
+- 2101 tests pass in ~7s - fast, fully deterministic suite
 - 100% bare `assert` usage across all tiers - zero unittest-style assertions
 - Excellent fixture architecture with centralized MockScorer, MockAdapter, MockExecutor factories
-- Module-level `pytestmark` compliance is near-universal across unit and integration tiers
+- Module-level `pytestmark` compliance is strong across unit and integration tiers
 - All random usage is seeded (`random.Random(42)`) - zero non-deterministic data
 - Clean async test patterns leveraging `asyncio_mode = "auto"` correctly
+- New `test_critic_preset_factory.py` is exemplary: 87 lines, 4 focused test classes, module-level pytestmark
 
 ### Key Weaknesses
 
-- 11 test files exceed 300 lines (test_models.py at 2528 lines is extreme)
-- Contract tests only ~8% follow the three-class template (RuntimeCheckable/Behavior/NonCompliance)
-- 6 integration files use raw `unittest.mock.patch` instead of pytest-mock's `mocker` fixture
+- 19 test files exceed 300 lines (test_models.py at 2528 lines is extreme) - corrected from 11 in prior review
+- Contract tests only ~3% follow the three-class template (RuntimeCheckable/Behavior/NonCompliance)
+- 10 integration files use raw `unittest.mock.patch` instead of pytest-mock's `mocker` fixture (up from 6)
 - ~12 individual integration tests exceed 50 lines
-- Several contract files missing `not isinstance()` non-compliance tests
+- 6 contract files missing module-level `pytestmark` (up from 4)
 
 ### Summary
 
-The gepa-adk test suite demonstrates production-grade quality with excellent fundamentals: fast execution, deterministic data, proper isolation, and consistent pytest conventions. The unit tier is exemplary. The primary areas for improvement are: (1) contract tests should adopt the documented three-class template more consistently, (2) large test files should be split by concern, and (3) a handful of integration tests should migrate from `unittest.mock.patch` to `mocker`. None of these are blocking issues.
+The gepa-adk test suite maintains production-grade quality with excellent fundamentals: fast execution, deterministic data, proper isolation, and consistent pytest conventions. The unit tier is exemplary. Since the last review (2026-03-06), 12 new tests were added with the well-structured `test_critic_preset_factory.py`. However, minor regressions appeared: 4 new integration files introduced `unittest.mock` imports, and 2 new contract files lack module-level `pytestmark`. The file-size count was corrected from 11 to 19 files exceeding 300 lines. The contract three-class template adoption remains the largest structural gap.
 
 ---
 
@@ -65,14 +66,14 @@ The gepa-adk test suite demonstrates production-grade quality with excellent fun
 | Data Factories                       | PASS    | 0          | MockScorer, MockAdapter, create_mock_adapter() factories |
 | Explicit Assertions                  | PASS    | 0          | 100% bare assert, pytest.raises, pytest.approx           |
 | Hard Waits (sleep, waitForTimeout)   | PASS    | 0          | No time.sleep() anywhere in test code                    |
-| Test Length (<=300 lines)            | WARN    | 11         | 11 files exceed 300 lines                                |
+| Test Length (<=300 lines)            | WARN    | 19         | 19 files exceed 300 lines (corrected from 11)            |
 | Flakiness Patterns                   | PASS    | 0          | No timing-dependent or env-dependent assertions          |
-| Test Tier Markers                    | WARN    | 4          | 4 contract files missing module-level pytestmark          |
-| Contract Three-Class Template        | FAIL    | ~22        | Only ~8% of protocol contract files follow template      |
-| Mocker vs unittest.mock              | WARN    | 6          | 6 integration files use raw unittest.mock.patch          |
+| Test Tier Markers                    | WARN    | 6          | 6 contract files missing module-level pytestmark          |
+| Contract Three-Class Template        | FAIL    | ~33        | Only ~1 of 36 protocol contract files follows template   |
+| Mocker vs unittest.mock              | WARN    | 10         | 10 integration files use raw unittest.mock (up from 6)   |
 | Individual Test Length (<=50 lines)  | WARN    | ~12        | ~12 integration tests exceed 50 lines                    |
 
-**Total Violations**: 0 Critical, 1 High, 4 Medium, 6 Low
+**Total Violations**: 0 Critical, 1 High, 4 Medium, 10 Low
 
 ---
 
@@ -83,17 +84,16 @@ Starting Score:          100
 Critical Violations:     -0 x 10 = -0
 High Violations:         -1 x 5 = -5     (contract template non-compliance pattern)
 Medium Violations:       -4 x 2 = -8     (file size, marker gaps, long tests, mock style)
-Low Violations:          -6 x 1 = -6     (individual unittest.mock.patch files)
+Low Violations:          -10 x 1 = -10   (individual unittest.mock.patch files, up from 6)
 
 Bonus Points:
   Comprehensive Fixtures: +5              (MockScorer, MockAdapter, create_mock_adapter)
   Perfect Isolation:      +5              (function scope, no shared state)
-  All Test IDs:           +0              (not applicable - Python backend)
-  Deterministic Data:     -1 (custom)     (already counted in base - not double-credited)
+  Deterministic Data:     -2 (custom)     (file size count correction from prior review)
                           --------
-Total Bonus:             +10
+Total Bonus:             +8
 
-Final Score:             82/100 (after clamping deductions for pattern-level issues at -5)
+Final Score:             80/100 (slight decline from 82 due to mock/marker regression)
 Grade:                   A (Good)
 ```
 
@@ -110,7 +110,7 @@ No critical issues detected.
 ### 1. Contract Tests: Adopt Three-Class Template
 
 **Severity**: P1 (High)
-**Location**: `tests/contracts/` (22+ files)
+**Location**: `tests/contracts/` (33+ files)
 **Criterion**: Contract Three-Class Template
 **Knowledge Base**: [test-quality.md](../../_bmad/tea/testarch/knowledge/test-quality.md)
 
@@ -120,7 +120,7 @@ Per the project's testing conventions (`.claude/rules/testing.md`), every Protoc
 2. `TestXxxProtocolBehavior` - behavioral expectations (return types, state transitions)
 3. `TestXxxProtocolNonCompliance` - negative cases (missing methods -> `not isinstance`)
 
-Only ~3 files (`test_stopper_protocol.py`, `test_agent_provider_protocol.py`, `test_evolution_result_protocol.py`) follow this template. The remaining ~22 files use single-class or module-function approaches.
+Only `test_stopper_protocol.py` fully follows this template with both `RuntimeCheckable` and `NonCompliance` classes. The remaining ~35 files use single-class or module-function approaches.
 
 **Compliant Example** (`test_stopper_protocol.py`):
 
@@ -166,7 +166,7 @@ class TestScorerProtocol:
 **Criterion**: Test Length
 **Knowledge Base**: [test-quality.md](../../_bmad/tea/testarch/knowledge/test-quality.md)
 
-**Files exceeding 300 lines**:
+**Files exceeding 300 lines** (corrected count - 19 files):
 
 | File | Lines | Recommendation |
 | ---- | ----- | -------------- |
@@ -174,13 +174,21 @@ class TestScorerProtocol:
 | `tests/unit/adapters/test_adk_adapter.py` | 1579 | Split by adapter method (evaluate, propose, reflect) |
 | `tests/unit/utils/test_events.py` | 1371 | Split by event type |
 | `tests/contracts/test_adk_adapter_contracts.py` | 1164 | Split contract vs behavior tests |
-| `tests/unit/test_api_state_guard.py` | 844 | Split by guard type |
 | `tests/unit/test_api.py` | 846 | Split by API function |
+| `tests/unit/test_api_state_guard.py` | 844 | Split by guard type |
 | `tests/unit/test_workflow.py` | 819 | Split by workflow type |
 | `tests/unit/adapters/test_multi_agent_adapter.py` | 765 | Split by adapter concern |
 | `tests/unit/test_encoding.py` | 695 | Split by encoding scenario |
 | `tests/unit/adapters/test_agent_executor.py` | 678 | Split by executor method |
 | `tests/unit/adapters/test_component_handlers.py` | 672 | Split by handler type |
+| `tests/unit/test_api_app_runner.py` | 635 | Split by runner concern |
+| `tests/unit/test_pre_flight_validation.py` | 626 | Split by validation type |
+| `tests/integration/test_component_handler_integration.py` | 579 | Split by handler scenario |
+| `tests/unit/engine/test_proposer.py` | 550 | Split by proposer behavior |
+| `tests/unit/engine/test_async_engine.py` | 546 | Split by engine concern |
+| `tests/integration/adapters/test_adk_adapter_integration.py` | 513 | Split by adapter path |
+| `tests/unit/domain/test_exceptions.py` | 492 | Split by exception category |
+| `tests/contracts/test_reflection_example_metadata.py` | 491 | Split by metadata concern |
 
 **Priority**: P2 - address incrementally when touching these files. The 300-line guideline is a readability heuristic, not a hard gate.
 
@@ -189,17 +197,21 @@ class TestScorerProtocol:
 ### 3. Migrate unittest.mock.patch to mocker Fixture
 
 **Severity**: P2 (Medium)
-**Location**: 6 integration test files
+**Location**: 10 integration test files (up from 6)
 **Criterion**: Mocking style consistency
 **Knowledge Base**: [test-quality.md](../../_bmad/tea/testarch/knowledge/test-quality.md)
 
-**Affected files**:
+**Affected files** (6 from prior review + 4 new):
 - `tests/integration/test_api_state_guard_logging.py`
 - `tests/integration/test_encoding_integration.py`
 - `tests/integration/test_unified_execution.py`
 - `tests/integration/test_executor_wiring_integration.py`
 - `tests/integration/test_critic_reflection_metadata.py`
-- `tests/integration/test_schema_reflection.py`
+- `tests/integration/test_stopper_integration.py`
+- `tests/integration/engine/test_reasoning_capture.py` *(new)*
+- `tests/integration/test_multimodal_evolution.py` *(new)*
+- `tests/integration/test_trajectory_capture.py` *(new)*
+- `tests/integration/adapters/test_adk_adapter_integration.py` *(new)*
 
 **Current Code**:
 
@@ -224,21 +236,23 @@ def test_something(mocker):
 
 **Benefits**: Automatic cleanup, consistent with unit test patterns, better pytest integration.
 
-**Priority**: P2 - address when touching these files.
+**Priority**: P2 - address when touching these files. Trend is worsening (+4 files since last review).
 
 ---
 
 ### 4. Contract Files Missing Module-Level pytestmark
 
 **Severity**: P3 (Low)
-**Location**: 4 contract files
+**Location**: 6 contract files (up from 4)
 **Criterion**: Test Tier Markers
 
 **Affected files**:
 - `tests/contracts/test_agent_executor_protocol.py` (uses class-level marks)
 - `tests/contracts/test_component_handler_protocol.py` (mixed module + class marks)
-- `tests/contracts/test_workflow_contracts.py` (missing entirely)
 - `tests/contracts/test_multi_agent_executor_contract.py` (missing entirely)
+- `tests/contracts/test_workflow_contracts.py` (missing entirely)
+- `tests/contracts/test_schema_constraints_contract.py` *(new - missing entirely)*
+- `tests/contracts/test_schema_utils_contract.py` *(new - missing entirely)*
 
 **Fix**: Add `pytestmark = pytest.mark.contract` at module level in each file.
 
@@ -297,7 +311,7 @@ adapter = create_mock_adapter(
 **Pattern**: Lazy evaluation of expensive checks
 
 **Why This Is Good**:
-The `pytest_collection_modifyitems` hook only probes Ollama/Gemini availability when the collected test set actually contains items with matching markers. Default runs (`-m 'not api'`) never trigger a network call. This keeps the 2.75s suite fast.
+The `pytest_collection_modifyitems` hook only probes Ollama/Gemini availability when the collected test set actually contains items with matching markers. Default runs (`-m 'not api'`) never trigger a network call. This keeps the suite fast.
 
 ```python
 # Probes only fire when needed
@@ -330,30 +344,46 @@ All randomness in tests uses instance-level `random.Random(42)` (or similar expl
 
 ---
 
+### 5. New: Exemplary Test File Structure (test_critic_preset_factory.py)
+
+**Location**: `tests/unit/adapters/scoring/test_critic_preset_factory.py`
+**Pattern**: Small, focused test file with class-per-concern
+
+**Why This Is Good**:
+At 87 lines, this new file is a model for test organization:
+- Module-level `pytestmark = pytest.mark.unit`
+- 4 focused test classes: `TestCreateCriticPresets`, `TestCreateCriticErrorHandling`, `TestCreateCriticModelOverride`, `TestCriticPresetsDict`
+- Clear docstrings on every test method
+- Tests one public API (`create_critic()`) with presets, errors, overrides, and re-exports
+
+**Use as Reference**: New test files should follow this structure.
+
+---
+
 ## Test File Analysis
 
 ### Suite Metadata
 
-- **Total Test Files**: 145 (test_*.py)
-- **Total Lines of Test Code**: 44,764
+- **Total Test Files**: 146 (test_*.py) - up from 145
+- **Total Lines of Test Code**: 44,876 - up from 44,764
 - **Test Framework**: pytest 8.4.2+ with pytest-asyncio, pytest-mock, pytest-xdist
 - **Language**: Python 3.12
 
 ### Test Structure
 
-- **Unit Tests**: ~73 files, ~27,728 lines
-- **Contract Tests**: ~34 files, ~7,947 lines
+- **Unit Tests**: ~74 files, ~28,000 lines
+- **Contract Tests**: ~36 files, ~8,100 lines
 - **Integration Tests**: ~36 files, ~12,000 lines
 - **Average Test Length**: ~15 lines per test method
 - **Fixtures**: Centralized in `tests/conftest.py` and `tests/fixtures/adapters.py`
 
 ### Test Scope
 
-- **Collected Tests**: 2,157 total (2,090 non-API)
-- **Passed**: 2,089
+- **Collected Tests**: 2,169 total (2,102 non-API)
+- **Passed**: 2,101
 - **Skipped**: 1 (placeholder: `test_async_engine_integration.py`)
 - **Deselected**: 67 (API-tier tests requiring Ollama/Gemini)
-- **Execution Time**: 2.75s
+- **Execution Time**: ~7s
 
 ### Priority Distribution
 
@@ -403,25 +433,25 @@ None required - suite is healthy.
 
 ### Follow-up Actions (Future PRs)
 
-1. **Standardize contract three-class template** - Refactor ~22 contract files to use RuntimeCheckable/Behavior/NonCompliance class structure
+1. **Standardize contract three-class template** - Refactor ~35 contract files to use RuntimeCheckable/Behavior/NonCompliance class structure
    - Priority: P1
    - Target: Next sprint touching contract tests
 
-2. **Split large test files** - Break up 11 files exceeding 300 lines
+2. **Split large test files** - Break up 19 files exceeding 300 lines (corrected from 11)
    - Priority: P2
    - Target: Incremental, when files are touched
 
-3. **Migrate unittest.mock to mocker** - Update 6 integration files
+3. **Migrate unittest.mock to mocker** - Update 10 integration files (growing trend)
    - Priority: P2
    - Target: Next sprint touching those files
 
-4. **Add missing pytestmark** - Fix 4 contract files
+4. **Add missing pytestmark** - Fix 6 contract files (up from 4)
    - Priority: P3
    - Target: Quick PR
 
 ### Re-Review Needed?
 
-No re-review needed - approve as-is. The findings are incremental improvements, not blocking issues.
+No re-review needed - approve as-is. The findings are incremental improvements, not blocking issues. Monitor the unittest.mock trend.
 
 ---
 
@@ -430,9 +460,9 @@ No re-review needed - approve as-is. The findings are incremental improvements, 
 **Recommendation**: Approve with Comments
 
 **Rationale**:
-Test quality is good with 82/100 score. The suite is fast (2.75s for 2089 tests), fully deterministic, well-isolated, and uses pytest conventions consistently. The primary gaps are structural: contract tests should adopt the three-class template documented in the project's own testing conventions, and several large files would benefit from splitting. The 6 files using raw `unittest.mock.patch` should migrate to `mocker` for consistency. None of these issues impact test reliability or correctness - they are maintainability improvements.
+Test quality remains good at 80/100 (slight decline from 82). The suite is fast (~7s for 2101 tests), fully deterministic, well-isolated, and uses pytest conventions consistently. New test additions (`test_critic_preset_factory.py`) are exemplary. The primary gaps remain structural: contract tests should adopt the three-class template, large files should be split, and the unittest.mock usage trend should be monitored. The file-size violation count was corrected from 11 to 19. None of these issues impact test reliability or correctness.
 
-> Test quality is good with 82/100 score. Minor structural improvements identified (contract template adoption, file splitting, mock style consistency) can be addressed in follow-up PRs. Tests are production-ready, fast, and reliable.
+> Test quality is good with 80/100 score. Minor structural regressions noted (unittest.mock trend +4 files, pytestmark gaps +2 files). File-size count corrected to 19. New test files are well-structured. Production-ready and reliable.
 
 ---
 
@@ -442,27 +472,61 @@ Test quality is good with 82/100 score. The suite is fast (2.75s for 2089 tests)
 
 | Location | Severity | Criterion | Issue | Fix |
 | -------- | -------- | --------- | ----- | --- |
-| tests/contracts/ (22 files) | P1 | Contract Template | Single-class instead of three-class | Refactor to RuntimeCheckable/Behavior/NonCompliance |
+| tests/contracts/ (35 files) | P1 | Contract Template | Single-class instead of three-class | Refactor to RuntimeCheckable/Behavior/NonCompliance |
 | tests/unit/domain/test_models.py | P2 | File Length | 2528 lines | Split by model class |
 | tests/unit/adapters/test_adk_adapter.py | P2 | File Length | 1579 lines | Split by adapter method |
 | tests/unit/utils/test_events.py | P2 | File Length | 1371 lines | Split by event type |
 | tests/contracts/test_adk_adapter_contracts.py | P2 | File Length | 1164 lines | Split contract vs behavior |
+| tests/unit/test_api.py | P2 | File Length | 846 lines | Split by API function |
+| tests/unit/test_api_state_guard.py | P2 | File Length | 844 lines | Split by guard type |
+| tests/unit/test_workflow.py | P2 | File Length | 819 lines | Split by workflow type |
+| tests/unit/adapters/test_multi_agent_adapter.py | P2 | File Length | 765 lines | Split by adapter concern |
+| tests/unit/test_encoding.py | P2 | File Length | 695 lines | Split by encoding scenario |
+| tests/unit/adapters/test_agent_executor.py | P2 | File Length | 678 lines | Split by executor method |
+| tests/unit/adapters/test_component_handlers.py | P2 | File Length | 672 lines | Split by handler type |
+| tests/unit/test_api_app_runner.py | P2 | File Length | 635 lines | Split by runner concern |
+| tests/unit/test_pre_flight_validation.py | P2 | File Length | 626 lines | Split by validation type |
+| tests/integration/test_component_handler_integration.py | P2 | File Length | 579 lines | Split by handler scenario |
+| tests/unit/engine/test_proposer.py | P2 | File Length | 550 lines | Split by proposer behavior |
+| tests/unit/engine/test_async_engine.py | P2 | File Length | 546 lines | Split by engine concern |
+| tests/integration/adapters/test_adk_adapter_integration.py | P2 | File Length | 513 lines | Split by adapter path |
+| tests/unit/domain/test_exceptions.py | P2 | File Length | 492 lines | Split by exception category |
+| tests/contracts/test_reflection_example_metadata.py | P2 | File Length | 491 lines | Split by metadata concern |
 | tests/integration/test_api_state_guard_logging.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
 | tests/integration/test_encoding_integration.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
 | tests/integration/test_unified_execution.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
 | tests/integration/test_executor_wiring_integration.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
 | tests/integration/test_critic_reflection_metadata.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
-| tests/integration/test_schema_reflection.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
+| tests/integration/test_stopper_integration.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
+| tests/integration/engine/test_reasoning_capture.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
+| tests/integration/test_multimodal_evolution.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
+| tests/integration/test_trajectory_capture.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
+| tests/integration/adapters/test_adk_adapter_integration.py | P3 | Mock Style | unittest.mock.patch | Use mocker fixture |
 | tests/contracts/test_workflow_contracts.py | P3 | Tier Marker | Missing pytestmark | Add module-level mark |
 | tests/contracts/test_multi_agent_executor_contract.py | P3 | Tier Marker | Missing pytestmark | Add module-level mark |
 | tests/contracts/test_agent_executor_protocol.py | P3 | Tier Marker | Class-level marks only | Move to module level |
 | tests/contracts/test_component_handler_protocol.py | P3 | Tier Marker | Mixed marking | Standardize to module level |
+| tests/contracts/test_schema_constraints_contract.py | P3 | Tier Marker | Missing pytestmark | Add module-level mark |
+| tests/contracts/test_schema_utils_contract.py | P3 | Tier Marker | Missing pytestmark | Add module-level mark |
 
 ### Quality Trends
 
 | Review Date | Score | Grade | Critical Issues | Trend |
 | ----------- | ----- | ----- | --------------- | ----- |
 | 2026-03-06  | 82/100 | A    | 0               | Baseline |
+| 2026-03-07  | 80/100 | A    | 0               | Slight decline (-2) |
+
+### Delta Summary (2026-03-06 to 2026-03-07)
+
+| Metric | Previous | Current | Change |
+| ------ | -------- | ------- | ------ |
+| Test files | 145 | 146 | +1 |
+| Tests passed | 2,089 | 2,101 | +12 |
+| Total lines | 44,764 | 44,876 | +112 |
+| Execution time | 2.75s | ~7s | +4.25s |
+| Files > 300 lines | 11 (reported) | 19 (corrected) | +8 (correction) |
+| pytestmark missing | 4 | 6 | +2 |
+| unittest.mock files | 6 | 10 | +4 |
 
 ---
 
@@ -470,6 +534,6 @@ Test quality is good with 82/100 score. The suite is fast (2.75s for 2089 tests)
 
 **Generated By**: BMad TEA Agent (Test Architect)
 **Workflow**: testarch-test-review v5.0
-**Review ID**: test-review-suite-20260306
-**Timestamp**: 2026-03-06
-**Version**: 1.0
+**Review ID**: test-review-suite-20260307
+**Timestamp**: 2026-03-07
+**Version**: 2.0 (update/merge from v1.0)

--- a/src/gepa_adk/__init__.py
+++ b/src/gepa_adk/__init__.py
@@ -38,7 +38,12 @@ Attributes:
     CriticOutput (class): Pydantic schema for advanced critic output.
     SIMPLE_CRITIC_INSTRUCTION (str): Default simple critic instruction.
     ADVANCED_CRITIC_INSTRUCTION (str): Default advanced critic instruction.
+    STRUCTURED_OUTPUT_CRITIC_INSTRUCTION (str): Preset instruction for structure evaluation.
+    ACCURACY_CRITIC_INSTRUCTION (str): Preset instruction for factual accuracy evaluation.
+    RELEVANCE_CRITIC_INSTRUCTION (str): Preset instruction for relevance evaluation.
     normalize_feedback (function): Normalize critic feedback to standard form.
+    create_critic (function): Factory for pre-configured critic agents by preset name.
+    critic_presets (dict): Maps preset name to human-readable description.
     evolve (function): Async single-agent evolution entry point.
     evolve_sync (function): Deprecated synchronous wrapper for evolve().
     evolve_group (function): Async multi-agent group evolution.
@@ -101,10 +106,15 @@ except Exception:
     __version__ = "0.0.0.dev"
 
 from gepa_adk.adapters.scoring.critic_scorer import (  # noqa: E402
+    ACCURACY_CRITIC_INSTRUCTION,
     ADVANCED_CRITIC_INSTRUCTION,
+    RELEVANCE_CRITIC_INSTRUCTION,
     SIMPLE_CRITIC_INSTRUCTION,
+    STRUCTURED_OUTPUT_CRITIC_INSTRUCTION,
     CriticOutput,
     SimpleCriticOutput,
+    create_critic,
+    critic_presets,
     normalize_feedback,
 )
 from gepa_adk.adapters.selection.component_selector import (  # noqa: E402
@@ -190,7 +200,12 @@ __all__ = [
     "CriticOutput",
     "SIMPLE_CRITIC_INSTRUCTION",
     "ADVANCED_CRITIC_INSTRUCTION",
+    "STRUCTURED_OUTPUT_CRITIC_INSTRUCTION",
+    "ACCURACY_CRITIC_INSTRUCTION",
+    "RELEVANCE_CRITIC_INSTRUCTION",
     "normalize_feedback",
+    "create_critic",
+    "critic_presets",
     # API
     "evolve",
     "evolve_sync",

--- a/src/gepa_adk/adapters/__init__.py
+++ b/src/gepa_adk/adapters/__init__.py
@@ -8,7 +8,7 @@ sub-packages and are no longer available.
 
 Sub-packages:
     execution/: Agent execution infrastructure (AgentExecutor, TrialBuilder).
-    scoring/: Scoring infrastructure (CriticScorer, schemas).
+    scoring/: Scoring infrastructure (CriticScorer, schemas, create_critic factory).
     evolution/: Core adapter implementations (ADKAdapter, MultiAgentAdapter).
     selection/: Selection strategies (candidates, components, evaluation).
     components/: Evolvable surface handlers (ComponentHandlerRegistry).
@@ -80,11 +80,16 @@ from gepa_adk.adapters.media.video_blob_service import (
 
 # Scoring
 from gepa_adk.adapters.scoring.critic_scorer import (
+    ACCURACY_CRITIC_INSTRUCTION,
     ADVANCED_CRITIC_INSTRUCTION,
+    RELEVANCE_CRITIC_INSTRUCTION,
     SIMPLE_CRITIC_INSTRUCTION,
+    STRUCTURED_OUTPUT_CRITIC_INSTRUCTION,
     CriticOutput,
     CriticScorer,
     SimpleCriticOutput,
+    create_critic,
+    critic_presets,
     normalize_feedback,
 )
 
@@ -142,7 +147,12 @@ __all__ = [
     "CriticOutput",
     "SIMPLE_CRITIC_INSTRUCTION",
     "ADVANCED_CRITIC_INSTRUCTION",
+    "STRUCTURED_OUTPUT_CRITIC_INSTRUCTION",
+    "ACCURACY_CRITIC_INSTRUCTION",
+    "RELEVANCE_CRITIC_INSTRUCTION",
     "normalize_feedback",
+    "create_critic",
+    "critic_presets",
     # Multi-agent
     "MultiAgentAdapter",
     "is_workflow_agent",

--- a/src/gepa_adk/adapters/scoring/__init__.py
+++ b/src/gepa_adk/adapters/scoring/__init__.py
@@ -1,9 +1,7 @@
 """Scoring infrastructure for evolution evaluation.
 
-Currently contains CriticScorer for LLM-based evaluation.
-
-Anticipated growth: create_critic() factory (Decision 3), preset-based scorer
-construction.
+Contains CriticScorer for LLM-based evaluation and the create_critic()
+preset factory for pre-configured critic agents.
 
 Attributes:
     CriticScorer: LLM-based scorer using critic agents.
@@ -19,15 +17,21 @@ Attributes:
     critic_presets: Maps preset name to human-readable description.
 
 Examples:
-    Create a simple critic scorer:
+    Create a critic scorer with an executor:
 
     ```python
-    from gepa_adk.adapters.scoring import CriticScorer, SimpleCriticOutput
+    from google.adk.agents import LlmAgent
+    from gepa_adk.adapters.scoring import CriticScorer, CriticOutput
+    from gepa_adk.adapters.execution.agent_executor import AgentExecutor
 
-    scorer = CriticScorer(
+    critic = LlmAgent(
+        name="quality_critic",
         model="gemini-2.5-flash",
-        output_schema=SimpleCriticOutput,
+        instruction="Evaluate response quality...",
+        output_schema=CriticOutput,
     )
+    executor = AgentExecutor()
+    scorer = CriticScorer(critic_agent=critic, executor=executor)
     ```
 
 See Also:

--- a/src/gepa_adk/adapters/scoring/__init__.py
+++ b/src/gepa_adk/adapters/scoring/__init__.py
@@ -11,7 +11,12 @@ Attributes:
     CriticOutput: Advanced schema with dimensions and guidance.
     SIMPLE_CRITIC_INSTRUCTION: Generic instruction for simple critics.
     ADVANCED_CRITIC_INSTRUCTION: Generic instruction for advanced critics.
+    STRUCTURED_OUTPUT_CRITIC_INSTRUCTION: Preset instruction for structure evaluation.
+    ACCURACY_CRITIC_INSTRUCTION: Preset instruction for factual accuracy evaluation.
+    RELEVANCE_CRITIC_INSTRUCTION: Preset instruction for relevance evaluation.
     normalize_feedback: Normalizes critic output to trial format.
+    create_critic: Factory for pre-configured critic agents by preset name.
+    critic_presets: Maps preset name to human-readable description.
 
 Examples:
     Create a simple critic scorer:
@@ -37,11 +42,16 @@ Note:
 """
 
 from gepa_adk.adapters.scoring.critic_scorer import (
+    ACCURACY_CRITIC_INSTRUCTION,
     ADVANCED_CRITIC_INSTRUCTION,
+    RELEVANCE_CRITIC_INSTRUCTION,
     SIMPLE_CRITIC_INSTRUCTION,
+    STRUCTURED_OUTPUT_CRITIC_INSTRUCTION,
     CriticOutput,
     CriticScorer,
     SimpleCriticOutput,
+    create_critic,
+    critic_presets,
     normalize_feedback,
 )
 
@@ -51,5 +61,10 @@ __all__ = [
     "CriticOutput",
     "SIMPLE_CRITIC_INSTRUCTION",
     "ADVANCED_CRITIC_INSTRUCTION",
+    "STRUCTURED_OUTPUT_CRITIC_INSTRUCTION",
+    "ACCURACY_CRITIC_INSTRUCTION",
+    "RELEVANCE_CRITIC_INSTRUCTION",
     "normalize_feedback",
+    "create_critic",
+    "critic_presets",
 ]

--- a/src/gepa_adk/adapters/scoring/critic_scorer.py
+++ b/src/gepa_adk/adapters/scoring/critic_scorer.py
@@ -289,7 +289,7 @@ def create_critic(name: str, *, model: str | None = None) -> LlmAgent:
     """Create a pre-configured critic agent by preset name.
 
     Args:
-        name: Preset name. One of: "structured_output", "accuracy", "relevance".
+        name: Preset name. Must be a key in ``_PRESET_INSTRUCTIONS``.
         model: Optional model override. When None, ADK uses its default.
 
     Returns:
@@ -299,9 +299,10 @@ def create_critic(name: str, *, model: str | None = None) -> LlmAgent:
         ConfigurationError: If name is not a valid preset.
     """
     if name not in _PRESET_INSTRUCTIONS:
+        valid_presets = ", ".join(sorted(_PRESET_INSTRUCTIONS))
         raise ConfigurationError(
-            f"Unknown critic preset '{name}'. Valid presets: {', '.join(critic_presets)}",
-            constraint=f"Must be one of: {', '.join(critic_presets)}",
+            f"Unknown critic preset '{name}'. Valid presets: {valid_presets}",
+            constraint=f"Must be one of: {valid_presets}",
             value=name,
             field="name",
         )

--- a/src/gepa_adk/adapters/scoring/critic_scorer.py
+++ b/src/gepa_adk/adapters/scoring/critic_scorer.py
@@ -14,7 +14,12 @@ Attributes:
     CriticOutput (class): Advanced schema with dimensions and guidance.
     SIMPLE_CRITIC_INSTRUCTION (str): Generic instruction for simple critics.
     ADVANCED_CRITIC_INSTRUCTION (str): Generic instruction for advanced critics.
+    STRUCTURED_OUTPUT_CRITIC_INSTRUCTION (str): Preset instruction for structure evaluation.
+    ACCURACY_CRITIC_INSTRUCTION (str): Preset instruction for factual accuracy evaluation.
+    RELEVANCE_CRITIC_INSTRUCTION (str): Preset instruction for relevance evaluation.
     normalize_feedback (function): Normalizes critic output to trial format.
+    create_critic (function): Factory for pre-configured critic agents by preset name.
+    critic_presets (dict): Maps preset name to human-readable description.
 
 Examples:
     Basic usage with LlmAgent critic:
@@ -58,11 +63,12 @@ import re
 from typing import Any
 
 import structlog
-from google.adk.agents import BaseAgent
+from google.adk.agents import BaseAgent, LlmAgent
 from google.adk.sessions import BaseSessionService, InMemorySessionService
 from pydantic import BaseModel, Field
 
 from gepa_adk.domain.exceptions import (
+    ConfigurationError,
     CriticOutputParseError,
     MissingScoreFieldError,
     ScoringError,
@@ -211,6 +217,105 @@ Provide:
 
 Be specific in your feedback - quote passages that work or don't work,
 and suggest alternatives where appropriate."""
+
+# -----------------------------------------------------------------------------
+# Preset Critic Instructions
+# -----------------------------------------------------------------------------
+STRUCTURED_OUTPUT_CRITIC_INSTRUCTION: str = """\
+Evaluate whether the output follows the expected structure and format.
+
+Score from 0.0 (completely malformed) to 1.0 (perfectly structured).
+
+In your feedback, diagnose specific structural issues: missing fields,
+wrong types, malformed JSON, schema violations. Quote the problematic
+sections and explain what the correct structure should be.
+
+Provide dimension_scores for: schema_compliance, field_completeness,
+type_correctness, format_consistency.
+
+In actionable_guidance, give concrete instructions for fixing each
+structural issue found. The guidance should be specific enough that
+a prompt editor can adjust the system prompt to prevent these issues."""
+
+ACCURACY_CRITIC_INSTRUCTION: str = """\
+Evaluate the factual accuracy and correctness of the output relative
+to the input and any expected answer.
+
+Score from 0.0 (completely wrong) to 1.0 (perfectly accurate).
+
+In your feedback, identify specific factual errors, logical flaws,
+or reasoning mistakes. Quote incorrect passages and explain what
+the correct answer or reasoning should be.
+
+Provide dimension_scores for: factual_correctness, reasoning_quality,
+completeness, consistency.
+
+In actionable_guidance, explain what knowledge or reasoning patterns
+the system prompt should emphasize to prevent these accuracy issues."""
+
+RELEVANCE_CRITIC_INSTRUCTION: str = """\
+Evaluate whether the output is relevant to the input query and
+addresses what was actually asked.
+
+Score from 0.0 (completely off-topic) to 1.0 (perfectly relevant).
+
+In your feedback, identify which aspects of the query were addressed,
+which were missed, and any tangential content that dilutes relevance.
+Quote specific passages that are on-topic or off-topic.
+
+Provide dimension_scores for: query_alignment, topic_coverage,
+completeness, focus.
+
+In actionable_guidance, explain how the system prompt should be
+adjusted to improve topical focus and query coverage."""
+
+# -----------------------------------------------------------------------------
+# Critic Preset Factory
+# -----------------------------------------------------------------------------
+critic_presets: dict[str, str] = {
+    "structured_output": "Scores output format/schema compliance with per-dimension diagnostics",
+    "accuracy": "Scores factual correctness with error diagnosis and improvement guidance",
+    "relevance": "Scores topical relevance with coverage analysis and focus guidance",
+}
+
+_PRESET_INSTRUCTIONS: dict[str, str] = {
+    "structured_output": STRUCTURED_OUTPUT_CRITIC_INSTRUCTION,
+    "accuracy": ACCURACY_CRITIC_INSTRUCTION,
+    "relevance": RELEVANCE_CRITIC_INSTRUCTION,
+}
+
+
+def create_critic(name: str, *, model: str | None = None) -> LlmAgent:
+    """Create a pre-configured critic agent by preset name.
+
+    Args:
+        name: Preset name. One of: "structured_output", "accuracy", "relevance".
+        model: Optional model override. When None, ADK uses its default.
+
+    Returns:
+        Configured LlmAgent with CriticOutput schema and preset instruction.
+
+    Raises:
+        ConfigurationError: If name is not a valid preset.
+    """
+    if name not in _PRESET_INSTRUCTIONS:
+        raise ConfigurationError(
+            f"Unknown critic preset '{name}'. Valid presets: {', '.join(critic_presets)}",
+            constraint=f"Must be one of: {', '.join(critic_presets)}",
+            value=name,
+            field="name",
+        )
+
+    model_kwargs: dict[str, Any] = {}
+    if model is not None:
+        model_kwargs["model"] = model
+
+    return LlmAgent(
+        name=f"{name}_critic",
+        instruction=_PRESET_INSTRUCTIONS[name],
+        output_schema=CriticOutput,
+        **model_kwargs,
+    )
 
 
 def normalize_feedback(
@@ -785,3 +890,18 @@ class CriticScorer:
             for better performance in async contexts.
         """
         return asyncio.run(self.async_score(input_text, output, expected))
+
+
+__all__ = [
+    "CriticScorer",
+    "SimpleCriticOutput",
+    "CriticOutput",
+    "SIMPLE_CRITIC_INSTRUCTION",
+    "ADVANCED_CRITIC_INSTRUCTION",
+    "STRUCTURED_OUTPUT_CRITIC_INSTRUCTION",
+    "ACCURACY_CRITIC_INSTRUCTION",
+    "RELEVANCE_CRITIC_INSTRUCTION",
+    "normalize_feedback",
+    "create_critic",
+    "critic_presets",
+]

--- a/tests/unit/adapters/scoring/__init__.py
+++ b/tests/unit/adapters/scoring/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for adapters.scoring sub-package."""

--- a/tests/unit/adapters/scoring/test_critic_preset_factory.py
+++ b/tests/unit/adapters/scoring/test_critic_preset_factory.py
@@ -1,0 +1,87 @@
+"""Tests for create_critic() factory and critic_presets dict."""
+
+import pytest
+from google.adk.agents import LlmAgent
+
+from gepa_adk.adapters.scoring.critic_scorer import (
+    CriticOutput,
+    create_critic,
+    critic_presets,
+)
+from gepa_adk.domain.exceptions import ConfigurationError
+
+pytestmark = pytest.mark.unit
+
+
+class TestCreateCriticPresets:
+    """Tests for each preset returning a correctly configured LlmAgent."""
+
+    def test_create_critic_structured_output_returns_llm_agent(self) -> None:
+        """Structured output preset returns LlmAgent with CriticOutput schema."""
+        agent = create_critic("structured_output")
+        assert isinstance(agent, LlmAgent)
+        assert agent.name == "structured_output_critic"
+        assert agent.output_schema == CriticOutput
+        assert "dimension_scores" in agent.instruction.lower()
+        assert "actionable_guidance" in agent.instruction.lower()
+
+    def test_create_critic_accuracy_returns_llm_agent(self) -> None:
+        """Accuracy preset returns LlmAgent with factual evaluation instruction."""
+        agent = create_critic("accuracy")
+        assert isinstance(agent, LlmAgent)
+        assert agent.name == "accuracy_critic"
+        assert agent.output_schema == CriticOutput
+        assert "factual" in agent.instruction.lower()
+
+    def test_create_critic_relevance_returns_llm_agent(self) -> None:
+        """Relevance preset returns LlmAgent with relevance evaluation instruction."""
+        agent = create_critic("relevance")
+        assert isinstance(agent, LlmAgent)
+        assert agent.name == "relevance_critic"
+        assert agent.output_schema == CriticOutput
+        assert "relevant" in agent.instruction.lower()
+
+
+class TestCreateCriticErrorHandling:
+    """Tests for invalid preset name error handling."""
+
+    def test_create_critic_invalid_name_raises_configuration_error(self) -> None:
+        """Invalid preset name raises ConfigurationError listing valid presets."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            create_critic("nonexistent")
+        assert exc_info.value.constraint is not None
+        assert "structured_output" in exc_info.value.constraint
+        assert "accuracy" in exc_info.value.constraint
+        assert "relevance" in exc_info.value.constraint
+
+
+class TestCreateCriticModelOverride:
+    """Tests for model passthrough behavior."""
+
+    def test_create_critic_with_model_passes_through(self) -> None:
+        """Model kwarg is forwarded to LlmAgent constructor."""
+        agent = create_critic("accuracy", model="some/model")
+        assert isinstance(agent, LlmAgent)
+        assert agent.model == "some/model"
+
+
+class TestCriticPresetsDict:
+    """Tests for critic_presets dict and re-exports."""
+
+    def test_critic_presets_is_dict_with_three_entries(self) -> None:
+        """critic_presets contains exactly three preset names."""
+        assert isinstance(critic_presets, dict)
+        assert len(critic_presets) == 3
+        assert set(critic_presets.keys()) == {
+            "structured_output",
+            "accuracy",
+            "relevance",
+        }
+
+    def test_create_critic_reexported_from_package(self) -> None:
+        """create_critic and critic_presets are importable from gepa_adk."""
+        from gepa_adk import create_critic as top_create_critic
+        from gepa_adk import critic_presets as top_critic_presets
+
+        assert callable(top_create_critic)
+        assert isinstance(top_critic_presets, dict)

--- a/tests/unit/adapters/test_adapter_reexports.py
+++ b/tests/unit/adapters/test_adapter_reexports.py
@@ -51,9 +51,34 @@ REEXPORT_CASES: list[tuple[str, str, str]] = [
         "ADVANCED_CRITIC_INSTRUCTION",
     ),
     (
+        "STRUCTURED_OUTPUT_CRITIC_INSTRUCTION",
+        "gepa_adk.adapters.scoring.critic_scorer",
+        "STRUCTURED_OUTPUT_CRITIC_INSTRUCTION",
+    ),
+    (
+        "ACCURACY_CRITIC_INSTRUCTION",
+        "gepa_adk.adapters.scoring.critic_scorer",
+        "ACCURACY_CRITIC_INSTRUCTION",
+    ),
+    (
+        "RELEVANCE_CRITIC_INSTRUCTION",
+        "gepa_adk.adapters.scoring.critic_scorer",
+        "RELEVANCE_CRITIC_INSTRUCTION",
+    ),
+    (
         "normalize_feedback",
         "gepa_adk.adapters.scoring.critic_scorer",
         "normalize_feedback",
+    ),
+    (
+        "create_critic",
+        "gepa_adk.adapters.scoring.critic_scorer",
+        "create_critic",
+    ),
+    (
+        "critic_presets",
+        "gepa_adk.adapters.scoring.critic_scorer",
+        "critic_presets",
     ),
     # Selection — candidate
     (


### PR DESCRIPTION
Developers had to manually configure LlmAgent critics with instruction
text and output schemas. This adds a one-call factory that returns
fully configured critic agents from preset names.

- Add `create_critic(name, *, model=None)` factory returning `LlmAgent` with `CriticOutput` schema
- Ship three MVP presets: `structured_output`, `accuracy`, `relevance` with ASI-optimized instructions
- Export `create_critic` and `critic_presets` dict through full chain to `gepa_adk.__init__`
- Add 7 unit tests covering all presets, error handling, model override, and re-exports
- Fix stale docstring and wrong constructor example in `scoring/__init__.py` (code review)

Test: `uv run pytest tests/unit/adapters/scoring/test_critic_preset_factory.py tests/unit/adapters/test_adapter_reexports.py -v`

docs(planning): add tech debt note for critic preset parallel dicts

Document maintenance coupling between `critic_presets` and
`_PRESET_INSTRUCTIONS` dicts in architecture Decision 3 and epics
Story 3.4 for consolidation before 4th preset.

chore(retrospective): add Epic 2 retrospective document

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `create_critic()` factory in `critic_scorer.py:288-318` — clean API surface, model passthrough pattern
- Parallel dicts (`critic_presets` + `_PRESET_INSTRUCTIONS`) — tech debt documented for Growth phase consolidation

### Related
- Architecture Decision 3 (Critic Presets) in `architecture.md`
- Story 3.4 (future: consolidate preset registry)