### PR TITLE
test(contracts): fill contract test gaps with three-class template and non-compliance tests

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "docvet": {
+      "command": "uvx",
+      "args": ["docvet[mcp]", "mcp"]
+    }
+  }
+}

--- a/_bmad-output/implementation-artifacts/3-2-fill-contract-test-gaps.md
+++ b/_bmad-output/implementation-artifacts/3-2-fill-contract-test-gaps.md
@@ -1,6 +1,6 @@
 # Story 3.2: Fill Contract Test Gaps
 
-Status: review
+Status: done
 
 ## Story
 
@@ -227,6 +227,7 @@ No issues encountered during implementation.
 - Task 4: Upgraded `test_multi_agent_adapter_protocol.py` from 1 class with 4 tests to three-class template. Split existing tests across RuntimeCheckable and Behavior classes, added 4 non-compliance tests (missing all methods, missing evaluate, missing propose, wrong signature). Test count: 4 -> 10
 - Task 5: Added `TestProposerProtocolNonCompliance` (2 tests), `TestMergeProposerProtocolNonCompliance` (2 tests), `TestVideoBlobServiceProtocolNonCompliance` (3 tests) to respective files without restructuring existing class layout
 - Task 6: Final verification -- 12/12 protocol coverage, 453 contract tests (was 430), all green, full suite 2124 passed / 1 skipped / 67 deselected
+- Code Review Fixes: (1) Fixed shared mutable RNG state in candidate_selector fixture with factory lambdas, (2) Removed constructor validation test from contract tier (already covered in unit tier), (3) Added missing make_reflective_dataset non-compliance test to multi_agent_adapter
 
 ### AC-to-Test Mapping
 
@@ -256,3 +257,4 @@ No issues encountered during implementation.
 ## Change Log
 
 - 2026-03-07: Implemented Story 3.2 -- upgraded 3 protocol test files to three-class template, added non-compliance tests to 3 additional files. Contract test count increased from 430 to 453 with zero regressions.
+- 2026-03-07: Code review fixes -- fixed shared mutable RNG state (M1), moved constructor test to unit tier (M2), added missing non-compliance test (L2). Test count unchanged at 453.

--- a/_bmad-output/implementation-artifacts/3-2-fill-contract-test-gaps.md
+++ b/_bmad-output/implementation-artifacts/3-2-fill-contract-test-gaps.md
@@ -1,0 +1,258 @@
+# Story 3.2: Fill Contract Test Gaps
+
+Status: review
+
+## Story
+
+As a contributor,
+I want every public Protocol contract test to cover all 4 minimum test types,
+so that the protocol coverage CI check passes and new implementations are validated with consistent coverage.
+
+## Acceptance Criteria
+
+1. `scripts/check_protocol_coverage.py` passes with zero missing Protocols (already true -- verify it stays green)
+2. Every protocol contract test file has at minimum 4 test types: isinstance check, method signature verification (async where applicable), happy-path behavioral, and non-compliance (missing methods -> `not isinstance`)
+3. `test_candidate_selector_protocol.py` is upgraded from 4 bare functions to three-class template with non-compliance tests
+4. `test_component_selector_protocol.py` is upgraded from 4 bare functions to three-class template (already has non-compliance test -- preserve it)
+5. `test_multi_agent_adapter_protocol.py` is upgraded from 3 minimal methods to three-class template with non-compliance tests
+6. Non-compliance tests added to: `test_proposer_protocol.py`, `test_merge_proposer_protocol.py`, `test_video_blob_service_protocol.py`
+7. All contract tests pass: `uv run pytest tests/contracts/ -x` completes green
+8. No regressions in existing test count (currently 430 contract tests -- count must not decrease)
+9. Three-class template (`RuntimeCheckable`, `Behavior`, `NonCompliance`) is the standard for new protocol test files going forward (established by the 3 upgraded files as exemplars alongside `test_stopper_protocol.py`)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Audit and baseline (AC: 1, 8)
+  - [x] 1.1 Run `python scripts/check_protocol_coverage.py` -- confirm 12/12 covered
+  - [x] 1.2 Run `uv run pytest tests/contracts/ --co -q` -- record baseline test count (430)
+
+- [x] Task 2: Upgrade `test_candidate_selector_protocol.py` (AC: 2, 3)
+  - [x] 2.1 Read existing file -- currently 4 bare functions, no test classes, no non-compliance
+  - [x] 2.2 Refactor into three-class template:
+    - `TestCandidateSelectorProtocolRuntimeCheckable` -- isinstance checks for all implementations
+    - `TestCandidateSelectorProtocolBehavior` -- return type, empty state edge case
+    - `TestCandidateSelectorProtocolNonCompliance` -- missing `select_candidate` method -> `not isinstance`
+  - [x] 2.3 Preserve all existing test coverage while adding non-compliance tests
+
+- [x] Task 3: Upgrade `test_component_selector_protocol.py` (AC: 2, 4)
+  - [x] 3.1 Read existing file -- currently 4 bare functions (1 is already non-compliance), no test classes
+  - [x] 3.2 Refactor into three-class template:
+    - `TestComponentSelectorProtocolRuntimeCheckable` -- isinstance checks
+    - `TestComponentSelectorProtocolBehavior` -- return type contracts, method signature
+    - `TestComponentSelectorProtocolNonCompliance` -- move existing non-compliance test here
+  - [x] 3.3 Preserve all existing test coverage (including existing non-compliance assertion at line 45)
+
+- [x] Task 4: Upgrade `test_multi_agent_adapter_protocol.py` (AC: 2, 5)
+  - [x] 4.1 Read existing file -- currently 3 methods in 1 class, no non-compliance
+  - [x] 4.2 Expand to three-class template:
+    - `TestMultiAgentAdapterProtocolRuntimeCheckable` -- isinstance with `AsyncGEPAAdapter`
+    - `TestMultiAgentAdapterProtocolBehavior` -- async method verification, return type contracts
+    - `TestMultiAgentAdapterProtocolNonCompliance` -- missing methods -> `not isinstance`
+  - [x] 4.3 Add behavioral tests: verify async method signatures for `evaluate()`, `make_reflective_dataset()`, `propose_new_texts()`
+
+- [x] Task 5: Add non-compliance tests to 3 files missing them (AC: 2, 6)
+  - [x] 5.1 `test_proposer_protocol.py` -- add non-compliance test (class missing `propose()` -> `not isinstance`)
+  - [x] 5.2 `test_merge_proposer_protocol.py` -- add non-compliance test (class missing `propose()` -> `not isinstance`)
+  - [x] 5.3 `test_video_blob_service_protocol.py` -- add non-compliance test (class missing `prepare_video_parts()` -> `not isinstance`)
+  - [x] 5.4 Do NOT restructure these files into three classes -- they already have solid behavioral coverage; only add non-compliance tests
+
+- [x] Task 6: Final verification (AC: 1, 7, 8)
+  - [x] 6.1 Run `python scripts/check_protocol_coverage.py` -- still 12/12
+  - [x] 6.2 Run `uv run pytest tests/contracts/ -x` -- all green
+  - [x] 6.3 Run `uv run pytest tests/contracts/ --co -q` -- count >= 430
+  - [x] 6.4 Run full suite `uv run pytest` -- no regressions
+
+## Dev Notes
+
+### Current State (2026-03-07)
+
+The epics.md AC originally stated `ProposerProtocol` and `VideoBlobServiceProtocol` lacked contract tests. Both now have comprehensive tests (10 and 14 tests respectively) added during prior work. The CI coverage check (`scripts/check_protocol_coverage.py`) passes 12/12.
+
+The real gaps are two-fold:
+1. **Structural**: 3 files use bare functions or minimal classes instead of the three-class template
+2. **Coverage**: 3 files (beyond those being upgraded) lack non-compliance tests entirely
+
+### Exemplar: test_stopper_protocol.py
+
+The stopper protocol test is the gold standard -- follow its pattern:
+```
+TestStopperProtocolRuntimeCheckable  (6 tests) -- isinstance checks, multiple implementations
+TestStopperProtocolBehavior          (4 tests) -- return types, state transitions
+TestStopperProtocolEdgeCases         (7 tests) -- boundary conditions
+TestStopperProtocolNonCompliance     (2 tests) -- missing methods, wrong signatures
+```
+[Source: tests/contracts/test_stopper_protocol.py]
+
+### Three-Class Template (from testing.md)
+
+1. `TestXxxProtocolRuntimeCheckable` -- positive compliance (`isinstance` checks)
+2. `TestXxxProtocolBehavior` -- behavioral expectations (return types, state transitions)
+3. `TestXxxProtocolNonCompliance` -- negative cases (missing methods -> `not isinstance`)
+
+### Weakest Files Requiring Upgrade
+
+| File | Tests | Classes | Issue |
+|------|-------|---------|-------|
+| `test_candidate_selector_protocol.py` | 4 | 0 (bare functions) | No classes, no non-compliance |
+| `test_component_selector_protocol.py` | 4 | 0 (bare functions) | No classes, no non-compliance |
+| `test_multi_agent_adapter_protocol.py` | 4 | 1 | Only 3 basic method-existence checks |
+
+### Files Missing Non-Compliance Tests (verified)
+
+Only 3 files with good behavioral coverage lack non-compliance tests:
+
+| File | Tests | Has NonCompliance | Action |
+|------|-------|-------------------|--------|
+| `test_proposer_protocol.py` | 10 | **No** | Add non-compliance test |
+| `test_merge_proposer_protocol.py` | 6 | **No** | Add non-compliance test |
+| `test_video_blob_service_protocol.py` | 14 | **No** | Add non-compliance test |
+
+### Files Already With Non-Compliance (no work needed)
+
+| File | Tests | Non-compliance line(s) |
+|------|-------|----------------------|
+| `test_scorer_protocol.py` | 12 | line 213 |
+| `test_adapter_protocol.py` | 9 | line 99 |
+| `test_agent_provider_protocol.py` | 13 | lines 217, 230, 243 |
+| `test_evolution_result_protocol.py` | 7 | line 192 |
+| `test_component_selector_protocol.py` | 4 | line 45 |
+
+### Non-Compliance Test Pattern
+
+```python
+class TestXxxProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
+
+    def test_missing_method_not_isinstance(self):
+        class Incomplete:
+            pass  # Missing required method(s)
+
+        assert not isinstance(Incomplete(), XxxProtocol)
+
+    def test_runtime_checkable_limitation_documented(self):
+        """@runtime_checkable only checks method existence, not signatures."""
+        class WrongSignature:
+            def required_method(self):  # Wrong signature (missing params)
+                ...
+
+        # isinstance passes because runtime_checkable doesn't check signatures
+        assert isinstance(WrongSignature(), XxxProtocol)
+```
+[Source: tests/contracts/test_stopper_protocol.py -- NonCompliance pattern]
+
+### Architecture Compliance
+
+- **Layer**: `tests/contracts/` -- contract test tier
+- **Marker**: `pytestmark = pytest.mark.contract` at module level (all existing files have this)
+- **Convention**: One test file per Protocol (not per implementation)
+- **Import**: Always import Protocol from `gepa_adk.ports` (not from internal module)
+
+### Existing Code to Reuse (DO NOT REINVENT)
+
+- `test_stopper_protocol.py` -- exemplar three-class template with all 4 test types
+- `test_component_handler_protocol.py` -- exemplar multi-implementation compliance testing
+- `test_evaluation_policy_protocol.py` -- exemplar parametrized testing across implementations
+- Existing mock implementations in each test file (e.g., `MockProposer`, `FixedScorer`) -- extend, don't replace
+- `MockScorer` / `mock_scorer_factory` in root conftest -- reuse for scorer-related testing
+
+### Refactoring Rules
+
+- **PRESERVE all existing tests** -- this is additive, not rewrite
+- When moving bare functions into classes, keep the same test names and assertions
+- For the 3 upgraded files (Tasks 2-4): use three-class template as these are exemplars
+- For the 3 files in Task 5: add non-compliance tests only -- do NOT restructure existing class layout
+- Don't change test logic that already passes -- only restructure and add
+- `pytestmark = pytest.mark.contract` must remain at module level
+
+### Party Mode Consensus (2026-03-07)
+
+Story scope was refined after team discussion (SM, Architect, Dev, TEA):
+- **AC relaxed**: Three-class template is MUST for new/upgraded files, not retroactively forced on existing files with good coverage
+- **Task 5 scope verified**: Only 3 files actually lack non-compliance tests (not 6 as originally estimated)
+- **Key principle**: Coverage of all 4 test types matters more than class structure conformity
+- **Forward standard**: Three-class template is the standard for new protocol test files going forward
+
+### Protocol Reference (all 12 in ports/)
+
+| Protocol | File | Key Methods |
+|----------|------|-------------|
+| `Scorer` | `ports/scorer.py` | `score()`, `async_score()` |
+| `ProposerProtocol` | `ports/proposer.py` | `propose()` |
+| `AsyncGEPAAdapter` | `ports/adapter.py` | `evaluate()`, `make_reflective_dataset()`, `propose_new_texts()` |
+| `StopperProtocol` | `ports/stopper.py` | `__call__()` |
+| `AgentProvider` | `ports/agent_provider.py` | `get_agent()`, `save_instruction()`, `list_agents()` |
+| `VideoBlobServiceProtocol` | `ports/video_blob_service.py` | `prepare_video_parts()`, `validate_video_file()` |
+| `CandidateSelectorProtocol` | `ports/candidate_selector.py` | `select_candidate()` |
+| `ComponentSelectorProtocol` | `ports/component_selector.py` | `select_components()` |
+| `EvaluationPolicyProtocol` | `ports/evaluation_policy.py` | `get_eval_batch()`, `get_best_candidate()`, `get_valset_score()` |
+| `AgentExecutorProtocol` | `ports/agent_executor.py` | `execute_agent()` |
+| `ComponentHandler` | `ports/component_handler.py` | `serialize()`, `apply()`, `restore()` |
+| `EvolutionResultProtocol` | `ports/evolution_result.py` | Data attrs + `improvement`, `improved` properties |
+
+### Documentation Impact
+
+No documentation impact (confirmed). Contract tests are internal quality infrastructure -- no user-facing docs change.
+
+### Project Structure Notes
+
+- All modifications in `tests/contracts/test_*_protocol.py` files (existing files)
+- No new files needed -- all protocol test files already exist
+- No changes to `src/` -- this is purely test-side work
+- `scripts/check_protocol_coverage.py` unchanged -- verify it still passes
+
+### References
+
+- [Source: tests/contracts/test_stopper_protocol.py -- exemplar three-class template]
+- [Source: .claude/rules/testing.md -- contract test three-class template and conventions]
+- [Source: _bmad-output/planning-artifacts/architecture.md -- Pattern 2: New Protocol Definition Recipe, minimum 4 tests]
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 3, Story 3.2]
+- [Source: scripts/check_protocol_coverage.py -- CI enforcement of Protocol-to-test mapping]
+- [Source: _bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md -- previous story learnings]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+No issues encountered during implementation.
+
+### Completion Notes List
+
+- Task 1: Baseline confirmed -- 12/12 protocol coverage, 430 contract tests
+- Task 2: Upgraded `test_candidate_selector_protocol.py` from 4 bare functions to three-class template (RuntimeCheckable, Behavior, NonCompliance). Added `test_select_candidate_returns_int` behavioral test and 2 non-compliance tests. Preserved all existing parametrized test coverage across 3 selector implementations. Test count: 10 -> 15
+- Task 3: Upgraded `test_component_selector_protocol.py` from 4 bare functions to three-class template. Added `RoundRobinComponentSelector` and `AllComponentSelector` isinstance checks, behavioral tests for return types. Preserved existing non-compliance test. Test count: 4 -> 9
+- Task 4: Upgraded `test_multi_agent_adapter_protocol.py` from 1 class with 4 tests to three-class template. Split existing tests across RuntimeCheckable and Behavior classes, added 4 non-compliance tests (missing all methods, missing evaluate, missing propose, wrong signature). Test count: 4 -> 10
+- Task 5: Added `TestProposerProtocolNonCompliance` (2 tests), `TestMergeProposerProtocolNonCompliance` (2 tests), `TestVideoBlobServiceProtocolNonCompliance` (3 tests) to respective files without restructuring existing class layout
+- Task 6: Final verification -- 12/12 protocol coverage, 453 contract tests (was 430), all green, full suite 2124 passed / 1 skipped / 67 deselected
+
+### AC-to-Test Mapping
+
+| AC | Test(s) | Status |
+|----|---------|--------|
+| AC1 | Task 6.1: `check_protocol_coverage.py` -> 12/12 | Pass |
+| AC2 | All 6 modified files now have isinstance, async/signature, behavioral, and non-compliance tests | Pass |
+| AC3 | `test_candidate_selector_protocol.py` -> 3 classes, 15 tests | Pass |
+| AC4 | `test_component_selector_protocol.py` -> 3 classes, 9 tests (non-compliance preserved) | Pass |
+| AC5 | `test_multi_agent_adapter_protocol.py` -> 3 classes, 10 tests | Pass |
+| AC6 | Non-compliance added to proposer (2), merge_proposer (2), video_blob (3) | Pass |
+| AC7 | `uv run pytest tests/contracts/ -x` -> 453 passed | Pass |
+| AC8 | 453 >= 430 baseline | Pass |
+| AC9 | 3 upgraded files + test_stopper_protocol.py serve as exemplars | Pass |
+
+### File List
+
+- `tests/contracts/test_candidate_selector_protocol.py` (modified -- restructured to three-class template)
+- `tests/contracts/test_component_selector_protocol.py` (modified -- restructured to three-class template)
+- `tests/contracts/test_multi_agent_adapter_protocol.py` (modified -- restructured to three-class template)
+- `tests/contracts/test_proposer_protocol.py` (modified -- added NonCompliance class)
+- `tests/contracts/test_merge_proposer_protocol.py` (modified -- added NonCompliance class)
+- `tests/contracts/test_video_blob_service_protocol.py` (modified -- added NonCompliance class)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified -- status ready-for-dev -> review)
+- `_bmad-output/implementation-artifacts/3-2-fill-contract-test-gaps.md` (modified -- task checkboxes, dev agent record)
+
+## Change Log
+
+- 2026-03-07: Implemented Story 3.2 -- upgraded 3 protocol test files to three-class template, added non-compliance tests to 3 additional files. Contract test count increased from 430 to 453 with zero regressions.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -81,7 +81,7 @@ development_status:
   # ── Epic 3: Evolution Control & Extensibility ──
   epic-3: in-progress
   3-1-implement-critic-preset-factory: done
-  3-2-fill-contract-test-gaps: backlog
+  3-2-fill-contract-test-gaps: review
   3-3-extension-point-documentation: backlog
   epic-3-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -81,7 +81,7 @@ development_status:
   # ── Epic 3: Evolution Control & Extensibility ──
   epic-3: in-progress
   3-1-implement-critic-preset-factory: done
-  3-2-fill-contract-test-gaps: review
+  3-2-fill-contract-test-gaps: done
   3-3-extension-point-documentation: backlog
   epic-3-retrospective: optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ dev = [
     # See: https://github.com/psf/requests/issues/issues
     "requests>=2.32.0,!=2.32.5",
     "uv-secure>=0.17.0",
-    "docvet>=1.7.0",
+    "docvet>=1.11.0",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ dev = [
     # See: https://github.com/psf/requests/issues/issues
     "requests>=2.32.0,!=2.32.5",
     "uv-secure>=0.17.0",
-    "docvet>=1.11.0",
+    "docvet[lsp,mcp]>=1.11.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/gepa_adk/adapters/stoppers/composite.py
+++ b/src/gepa_adk/adapters/stoppers/composite.py
@@ -37,6 +37,12 @@ Examples:
 Note:
     This composite stopper is useful for building complex termination
     policies from simpler building blocks.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/adapters/stoppers/evaluations.py
+++ b/src/gepa_adk/adapters/stoppers/evaluations.py
@@ -31,6 +31,12 @@ Note:
     This stopper is particularly useful for controlling API costs when using
     expensive model evaluations. The evaluation count is cumulative across
     all iterations.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
 """
 
 from gepa_adk.domain.stopper import StopperState

--- a/src/gepa_adk/adapters/stoppers/file.py
+++ b/src/gepa_adk/adapters/stoppers/file.py
@@ -31,6 +31,12 @@ Note:
     This stopper is particularly useful for CI/CD pipelines, job schedulers,
     and external monitoring systems that cannot easily send process signals
     but can create files.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
 """
 
 from pathlib import Path

--- a/src/gepa_adk/adapters/stoppers/signal.py
+++ b/src/gepa_adk/adapters/stoppers/signal.py
@@ -34,6 +34,12 @@ Examples:
 Note:
     This stopper requires careful integration with asyncio's event loop
     for proper signal handling in async contexts.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/adapters/stoppers/threshold.py
+++ b/src/gepa_adk/adapters/stoppers/threshold.py
@@ -20,6 +20,12 @@ Examples:
 Note:
     This stopper is useful when you have a known target score and want to
     terminate as soon as it is reached, rather than continuing unnecessarily.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/adapters/stoppers/timeout.py
+++ b/src/gepa_adk/adapters/stoppers/timeout.py
@@ -20,6 +20,12 @@ Examples:
 Note:
     This stopper is the simplest implementation and serves as a good
     template for other stoppers.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/domain/exceptions.py
+++ b/src/gepa_adk/domain/exceptions.py
@@ -25,6 +25,12 @@ Examples:
 Note:
     The exception hierarchy provides structured error handling with
     contextual information for debugging and error recovery.
+
+See Also:
+    - [`gepa_adk.domain.models`][gepa_adk.domain.models]: Domain models that
+        raise these exceptions during validation.
+    - [`gepa_adk.ports.adapter`][gepa_adk.ports.adapter]: Adapter protocol whose
+        implementations raise EvaluationError and AdapterError.
 """
 
 from typing import Any
@@ -169,7 +175,10 @@ class NoCandidateAvailableError(EvolutionError):
         Args:
             message: Human-readable error description.
             cause: Original exception that caused this error.
-            **context: Additional context such as candidate_idx or frontier_type.
+
+        Other Parameters:
+            **context: Arbitrary key-value pairs stored as exception attributes
+                for debugging context.
 
         Note:
             Context fields use keyword-only syntax to ensure explicit labeling
@@ -241,7 +250,10 @@ class EvaluationError(EvolutionError):
         Args:
             message: Human-readable error description.
             cause: Original exception that caused this error.
-            **context: Additional context for debugging (agent_name, etc.).
+
+        Other Parameters:
+            **context: Arbitrary key-value pairs stored as exception attributes
+                for debugging context.
 
         Note:
             Context is passed via keyword arguments. Positional arguments

--- a/src/gepa_adk/domain/state.py
+++ b/src/gepa_adk/domain/state.py
@@ -1,7 +1,28 @@
 """Domain models for Pareto frontier tracking.
 
+Examples:
+    Basic ParetoState usage:
+
+    ```python
+    from gepa_adk.domain.models import Candidate
+    from gepa_adk.domain.state import ParetoState
+
+    state = ParetoState()
+    idx = state.add_candidate(
+        Candidate(components={"instruction": "Be helpful."}),
+        [0.8, 0.7, 0.9],
+    )
+    print(state.get_average_score(idx))  # 0.8
+    ```
+
 Note:
     This module captures Pareto frontier leaders and candidate state.
+
+See Also:
+    - [`gepa_adk.domain.models.Candidate`][gepa_adk.domain.models.Candidate]:
+        Domain model stored by ParetoState during evolution.
+    - [`gepa_adk.ports.candidate_selector`][gepa_adk.ports.candidate_selector]:
+        Protocol that consumes ParetoState for parent selection.
 """
 
 from __future__ import annotations
@@ -54,27 +75,28 @@ class ParetoFrontier:
     """Tracks non-dominated candidates across multiple frontier dimensions.
 
     Attributes:
-        example_leaders (dict[int, set[int]]): Instance-level: example_idx →
-            leader candidate indices.
-        best_scores (dict[int, float]): Instance-level: example_idx → best score.
-        objective_leaders (dict[str, set[int]]): Objective-level: objective_name →
-            leader candidate indices.
-        objective_best_scores (dict[str, float]): Objective-level: objective_name →
-            best score.
-        cartesian_leaders (dict[tuple[int, str], set[int]]): Cartesian:
-            (example_idx, objective) → leader candidate indices.
-        cartesian_best_scores (dict[tuple[int, str], float]): Cartesian:
-            (example_idx, objective) → best score.
-
-    Note:
-        A frontier stores the best candidate indices per dimension for sampling.
-        The active dimension depends on frontier_type.
+        example_leaders (dict[int, set[int]]): Instance-level mapping of
+            example_idx to leader candidate indices.
+        best_scores (dict[int, float]): Instance-level mapping of
+            example_idx to best score.
+        objective_leaders (dict[str, set[int]]): Objective-level mapping of
+            objective_name to leader candidate indices.
+        objective_best_scores (dict[str, float]): Objective-level mapping of
+            objective_name to best score.
+        cartesian_leaders (dict[tuple[int, str], set[int]]): Cartesian mapping of
+            (example_idx, objective) to leader candidate indices.
+        cartesian_best_scores (dict[tuple[int, str], float]): Cartesian mapping of
+            (example_idx, objective) to best score.
 
     Examples:
         ```python
         frontier = ParetoFrontier()
         frontier.update(0, {0: 0.8, 1: 0.6})
         ```
+
+    Note:
+        A frontier stores the best candidate indices per dimension for sampling.
+        The active dimension depends on frontier_type.
     """
 
     example_leaders: dict[int, set[int]] = field(default_factory=dict)
@@ -323,22 +345,24 @@ class ParetoState:
 
     Attributes:
         candidates (list[Candidate]): Candidates discovered during evolution.
-        candidate_scores (dict[int, dict[int, float]]): Per-example scores.
+        candidate_scores (dict[int, dict[int, float]]): Per-example scores
+            mapping candidate index to example-score mappings.
         frontier (ParetoFrontier): Current frontier leader sets.
         frontier_type (FrontierType): Frontier tracking strategy.
         iteration (int): Current iteration number.
         best_average_idx (int | None): Index of best-average candidate.
         parent_indices (dict[int, list[int | None]]): Genealogy map tracking
-            parent relationships. Maps candidate_idx → [parent_idx, ...] or [None] for seeds.
-
-    Note:
-        A single state object keeps frontier and candidate metrics aligned.
+            parent relationships, mapping candidate_idx to parent index list
+            or ``[None]`` for seeds.
 
     Examples:
         ```python
         state = ParetoState()
         state.add_candidate(Candidate(components={"instruction": "seed"}), [0.5])
         ```
+
+    Note:
+        A single state object keeps frontier and candidate metrics aligned.
     """
 
     candidates: list[Candidate] = field(default_factory=list)
@@ -355,6 +379,10 @@ class ParetoState:
 
     def __post_init__(self) -> None:
         """Validate state configuration and initialize averages.
+
+        Raises:
+            ConfigurationError: If any candidate_scores index exceeds the
+                candidates list length.
 
         Note:
             Checks candidate_scores indices are valid and marks frontier_type
@@ -375,6 +403,10 @@ class ParetoState:
 
     def __setattr__(self, name: str, value: object) -> None:
         """Enforce frontier_type immutability after initialization (T069).
+
+        Raises:
+            ConfigurationError: If frontier_type is changed after
+                ParetoState initialization.
 
         Note:
             Only frontier_type is protected because it determines the frontier
@@ -405,7 +437,11 @@ class ParetoState:
     def _validate_parent_indices(
         indices: Sequence[int | None], label: str
     ) -> list[int | None]:
-        """Validate parent indices for genealogy tracking."""
+        """Validate parent indices for genealogy tracking.
+
+        Raises:
+            TypeError: If any element in indices is not int or None.
+        """
         validated: list[int | None] = []
         for idx, parent_idx in enumerate(indices):
             if not (isinstance(parent_idx, int) or parent_idx is None):

--- a/src/gepa_adk/domain/stopper.py
+++ b/src/gepa_adk/domain/stopper.py
@@ -26,6 +26,10 @@ Note:
     This StopperState snapshot is intentionally minimal. Add fields as needed
     for specific stopper implementations. The frozen dataclass ensures stoppers
     cannot accidentally mutate evolution state.
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface that consumes StopperState for stop decisions.
 """
 
 from dataclasses import dataclass

--- a/src/gepa_adk/domain/trajectory.py
+++ b/src/gepa_adk/domain/trajectory.py
@@ -3,9 +3,28 @@
 This module defines data structures for capturing agent execution traces,
 including tool calls, state changes, and token usage metrics.
 
+Examples:
+    Creating a trajectory from an agent evaluation:
+
+    ```python
+    from gepa_adk.domain.trajectory import ADKTrajectory, TokenUsage, ToolCallRecord
+
+    trajectory = ADKTrajectory(
+        tool_calls=(ToolCallRecord("search", {"q": "AI"}, ["result"], 0.1),),
+        state_deltas=(),
+        token_usage=TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+        final_output="Search complete.",
+        error=None,
+    )
+    ```
+
 Note:
     These types are immutable (frozen dataclasses) to ensure trajectory data
     cannot be modified after capture, maintaining audit integrity.
+
+See Also:
+    - [`gepa_adk.ports.adapter.EvaluationBatch`][gepa_adk.ports.adapter.EvaluationBatch]:
+        Adapter protocol that produces trajectory data during evaluation.
 """
 
 from dataclasses import dataclass

--- a/src/gepa_adk/engine/genealogy.py
+++ b/src/gepa_adk/engine/genealogy.py
@@ -29,6 +29,12 @@ Examples:
     # Returns: 0
     ```
 
+See Also:
+    - [`ParetoState`][gepa_adk.domain.state.ParetoState]: Evolution state that
+      stores parent indices consumed by genealogy queries.
+    - [`Candidate`][gepa_adk.domain.models.Candidate]: Domain model whose
+      lineage is tracked by these functions.
+
 Note:
     This module provides genealogy tracking functions for merge operations.
     Genealogy tracking enables merge operations by identifying which candidates

--- a/src/gepa_adk/engine/merge_proposer.py
+++ b/src/gepa_adk/engine/merge_proposer.py
@@ -20,6 +20,12 @@ Examples:
         print(f"Merged from parents {result.parent_indices}")
     ```
 
+See Also:
+    - [`ProposerProtocol`][gepa_adk.ports.proposer.ProposerProtocol]: Protocol
+      that MergeProposer implements.
+    - [`ParetoState`][gepa_adk.domain.state.ParetoState]: Evolution state
+      consumed by the propose method.
+
 Note:
     This module provides genetic crossover capabilities for evolution.
     MergeProposer implements ProposerProtocol and can be used alongside

--- a/src/gepa_adk/ports/adapter.py
+++ b/src/gepa_adk/ports/adapter.py
@@ -1,5 +1,33 @@
 """Protocol definitions for async adapters.
 
+This module defines the AsyncGEPAAdapter protocol and the EvaluationBatch
+dataclass that together form the contract between the evolution engine and
+external evaluation systems.
+
+Attributes:
+    EvaluationBatch (dataclass): Container for evaluation outputs and scores.
+    AsyncGEPAAdapter (protocol): Protocol for async GEPA adapters.
+
+Examples:
+    Create an EvaluationBatch with scores and outputs:
+
+    ```python
+    from gepa_adk.ports.adapter import EvaluationBatch
+
+    batch = EvaluationBatch(
+        outputs=["Hello!", "Good day!"],
+        scores=[0.8, 0.95],
+        inputs=["Greet casually", "Greet formally"],
+    )
+    assert len(batch.scores) == 2
+    ```
+
+See Also:
+    - [`ProposerProtocol`][gepa_adk.ports.proposer.ProposerProtocol]:
+        Consumes EvaluationBatch for reflective proposals.
+    - [`gepa_adk.domain.models`][gepa_adk.domain.models]: Domain models used
+        alongside adapter results.
+
 Note:
     This module defines the core protocol interface that connects
     gepa-adk's evolution engine to external evaluation systems.

--- a/src/gepa_adk/ports/agent_executor.py
+++ b/src/gepa_adk/ports/agent_executor.py
@@ -51,9 +51,9 @@ class ExecutionStatus(str, Enum):
     used by ExecutionResult to indicate how the execution completed.
 
     Attributes:
-        SUCCESS: Agent completed execution normally with valid output.
-        FAILED: Agent encountered an error during execution.
-        TIMEOUT: Agent execution exceeded configured timeout.
+        SUCCESS (str): Agent completed execution normally with valid output.
+        FAILED (str): Agent encountered an error during execution.
+        TIMEOUT (str): Agent execution exceeded configured timeout.
 
     Examples:
         Checking execution status:

--- a/src/gepa_adk/ports/agent_provider.py
+++ b/src/gepa_adk/ports/agent_provider.py
@@ -46,6 +46,11 @@ Examples:
     provider.save_instruction("my_agent", "New instruction")
     ```
 
+See Also:
+    - [`AgentExecutorProtocol`][gepa_adk.ports.agent_executor.AgentExecutorProtocol]:
+        Executes agents loaded by a provider.
+    - [`gepa_adk.engine`][gepa_adk.engine]: Evolution engine that consumes agent providers.
+
 Note:
     The protocol uses sync methods for simplicity. Implementations that need
     async can use async internally and block in sync methods, or provide

--- a/src/gepa_adk/ports/candidate_selector.py
+++ b/src/gepa_adk/ports/candidate_selector.py
@@ -2,6 +2,30 @@
 
 Attributes:
     CandidateSelectorProtocol: Async protocol for candidate selection strategies.
+
+Examples:
+    Implement a simple random selector:
+
+    ```python
+    import random
+
+    from gepa_adk.ports.candidate_selector import CandidateSelectorProtocol
+    from gepa_adk.domain.state import ParetoState
+
+
+    class RandomSelector:
+        async def select_candidate(self, state: ParetoState) -> int:
+            frontier = state.pareto_frontier
+            return random.choice(frontier) if frontier else 0
+
+
+    selector = RandomSelector()
+    assert isinstance(selector, CandidateSelectorProtocol)
+    ```
+
+See Also:
+    - [`ParetoState`][gepa_adk.domain.state.ParetoState]: Evolution state
+        consumed by candidate selectors.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/ports/component_handler.py
+++ b/src/gepa_adk/ports/component_handler.py
@@ -32,8 +32,10 @@ Examples:
     ```
 
 See Also:
-    - [`gepa_adk.adapters.components.component_handlers`]: Built-in handler implementations.
-    - [`gepa_adk.adapters.evolution.adk_adapter`]: Usage in ADKAdapter._apply_candidate().
+    - [`component_handlers`][gepa_adk.adapters.components.component_handlers]:
+        Built-in handler implementations.
+    - [`adk_adapter`][gepa_adk.adapters.evolution.adk_adapter]:
+        Usage in ADKAdapter._apply_candidate().
 
 Note:
     This protocol follows the hexagonal architecture pattern - it is defined
@@ -88,11 +90,11 @@ class ComponentHandler(Protocol):
         ```
 
     See Also:
-        - [`InstructionHandler`]
-            [gepa_adk.adapters.components.component_handlers.InstructionHandler]:
+        - [`InstructionHandler`]\
+[gepa_adk.adapters.components.component_handlers.InstructionHandler]:
             Handler for agent instruction.
-        - [`OutputSchemaHandler`]
-            [gepa_adk.adapters.components.component_handlers.OutputSchemaHandler]:
+        - [`OutputSchemaHandler`]\
+[gepa_adk.adapters.components.component_handlers.OutputSchemaHandler]:
             Handler for agent output schema.
 
     Note:

--- a/src/gepa_adk/ports/component_selector.py
+++ b/src/gepa_adk/ports/component_selector.py
@@ -2,6 +2,29 @@
 
 Attributes:
     ComponentSelectorProtocol: Async protocol for component selection strategies.
+
+Examples:
+    Implement a round-robin component selector:
+
+    ```python
+    from gepa_adk.ports.component_selector import ComponentSelectorProtocol
+
+
+    class RoundRobinSelector:
+        async def select_components(
+            self, components: list[str], iteration: int, candidate_idx: int
+        ) -> list[str]:
+            idx = iteration % len(components)
+            return [components[idx]]
+
+
+    selector = RoundRobinSelector()
+    assert isinstance(selector, ComponentSelectorProtocol)
+    ```
+
+See Also:
+    - [`gepa_adk.adapters.selection`][gepa_adk.adapters.selection]: Built-in
+        component selection strategy implementations.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/ports/evaluation_policy.py
+++ b/src/gepa_adk/ports/evaluation_policy.py
@@ -2,6 +2,41 @@
 
 Attributes:
     EvaluationPolicyProtocol: Protocol for valset evaluation strategies.
+
+Examples:
+    Implement a full-evaluation policy:
+
+    ```python
+    from gepa_adk.ports.evaluation_policy import EvaluationPolicyProtocol
+    from gepa_adk.domain.state import ParetoState
+    from typing import Sequence
+
+
+    class FullEvalPolicy:
+        def get_eval_batch(
+            self,
+            valset_ids: Sequence[int],
+            state: ParetoState,
+            target_candidate_idx: int | None = None,
+        ) -> list[int]:
+            return list(valset_ids)
+
+        def get_best_candidate(self, state: ParetoState) -> int:
+            return 0
+
+        def get_valset_score(self, candidate_idx: int, state: ParetoState) -> float:
+            return 0.0
+
+
+    policy = FullEvalPolicy()
+    assert isinstance(policy, EvaluationPolicyProtocol)
+    ```
+
+See Also:
+    - [`gepa_adk.engine`][gepa_adk.engine]: Evolution engine that uses
+        evaluation policies.
+    - [`AsyncGEPAAdapter`][gepa_adk.ports.adapter.AsyncGEPAAdapter]: Adapter
+        protocol that performs the evaluations selected by policies.
 """
 
 from __future__ import annotations

--- a/src/gepa_adk/ports/proposer.py
+++ b/src/gepa_adk/ports/proposer.py
@@ -31,6 +31,10 @@ Examples:
             )
     ```
 
+See Also:
+    - [`ParetoState`][gepa_adk.domain.state.ParetoState]: Evolution state consumed by proposers.
+    - [`ProposalResult`][gepa_adk.domain.types.ProposalResult]: Return type for proposals.
+
 Note:
     This module defines the protocol interface for candidate proposal strategies.
     All proposers return None when no valid proposal can be generated.

--- a/src/gepa_adk/ports/scorer.py
+++ b/src/gepa_adk/ports/scorer.py
@@ -45,6 +45,10 @@ Examples:
     assert metadata["exact_match"] is True
     ```
 
+See Also:
+    - [`gepa_adk.adapters`][gepa_adk.adapters]: Scorer implementations
+        (e.g., CriticScorer, exact-match scorers).
+
 Note:
     The protocol defines both synchronous and asynchronous scoring methods
     to support various use cases. Score values should be normalized between

--- a/src/gepa_adk/ports/stopper.py
+++ b/src/gepa_adk/ports/stopper.py
@@ -28,6 +28,10 @@ Examples:
     assert isinstance(stopper, StopperProtocol)
     ```
 
+See Also:
+    - [`StopperState`][gepa_adk.domain.stopper.StopperState]: State snapshot passed to stoppers.
+    - [`gepa_adk.adapters.stoppers`][gepa_adk.adapters.stoppers]: Built-in stopper implementations.
+
 Note:
     This protocol is runtime_checkable, allowing isinstance() checks
     to work without explicit inheritance and follows the structural

--- a/src/gepa_adk/ports/video_blob_service.py
+++ b/src/gepa_adk/ports/video_blob_service.py
@@ -44,6 +44,10 @@ Examples:
     assert isinstance(service, VideoBlobServiceProtocol)
     ```
 
+See Also:
+    - [`VideoFileInfo`][gepa_adk.domain.models.VideoFileInfo]: Metadata returned by validation.
+    - [`gepa_adk.adapters.media`][gepa_adk.adapters.media]: Video blob service implementations.
+
 Note:
     The protocol uses list[Any] as the return type for prepare_video_parts()
     to avoid importing ADK types in the ports layer. Implementations in the

--- a/src/gepa_adk/utils/encoding.py
+++ b/src/gepa_adk/utils/encoding.py
@@ -14,7 +14,7 @@ This approach ensures log output is always writable to the console without
 raising exceptions, while preserving as much of the original meaning as
 possible.
 
-Example:
+Examples:
     Add to structlog processor chain before the renderer:
 
     ```python
@@ -36,8 +36,10 @@ Example:
     ```
 
 See Also:
-    - ADR-011: Cross-Platform Encoding for design decisions
-    - ADR-008: Structured Logging for processor chain patterns
+    - [`EncodingSafeProcessor`][gepa_adk.utils.encoding.EncodingSafeProcessor]: The
+      processor class provided by this module.
+    - [`structlog.dev.ConsoleRenderer`][structlog.dev.ConsoleRenderer]: Renderer
+      that this processor should precede in the chain.
 
 Note:
     This processor is designed to be transparent on UTF-8 consoles (macOS,

--- a/src/gepa_adk/utils/state_guard.py
+++ b/src/gepa_adk/utils/state_guard.py
@@ -1,4 +1,4 @@
-"""StateGuard utility for preserving ADK state injection tokens.
+r"""StateGuard utility for preserving ADK state injection tokens.
 
 This module provides the StateGuard class which validates and repairs mutated
 component_text to ensure required state injection tokens are preserved and
@@ -7,6 +7,25 @@ unauthorized tokens are escaped.
 Terminology:
     - **component_text**: The text content being evolved (e.g., agent instruction)
     - **token**: ADK state injection placeholder (e.g., {user_id}, {context})
+
+Examples:
+    Guard required tokens during component evolution:
+
+    ```python
+    from gepa_adk.utils.state_guard import StateGuard
+
+    guard = StateGuard(required_tokens=["{user_id}", "{context}"])
+    original = "Hello {user_id}, context: {context}"
+    mutated = "Hello {user_id}, welcome!"
+    result = guard.validate(original, mutated)
+    # result == "Hello {user_id}, welcome!\n\n{context}"
+    ```
+
+See Also:
+    - [`StateGuard`][gepa_adk.utils.state_guard.StateGuard]: The guard class
+      provided by this module.
+    - [`gepa_adk.engine.reflection`][gepa_adk.engine.reflection]: Reflection
+      engine whose output is validated by StateGuard.
 
 Note:
     This utility ensures ADK state injection tokens (e.g., {user_id}) remain

--- a/tests/contracts/test_candidate_selector_protocol.py
+++ b/tests/contracts/test_candidate_selector_protocol.py
@@ -19,16 +19,6 @@ from gepa_adk.ports.candidate_selector import CandidateSelectorProtocol
 pytestmark = pytest.mark.contract
 
 
-def test_import_path_equivalence() -> None:
-    """CandidateSelectorProtocol is accessible from both import paths."""
-    from gepa_adk.ports import CandidateSelectorProtocol as from_init
-    from gepa_adk.ports.candidate_selector import (
-        CandidateSelectorProtocol as from_module,
-    )
-
-    assert from_init is from_module
-
-
 @pytest.fixture
 def pareto_state() -> ParetoState:
     """Create a minimal ParetoState with two candidates."""
@@ -56,24 +46,67 @@ def selector(request) -> CandidateSelectorProtocol:
     return request.param
 
 
-def test_is_protocol_compliant(selector: CandidateSelectorProtocol) -> None:
-    """Selectors implement CandidateSelectorProtocol."""
-    assert isinstance(selector, CandidateSelectorProtocol)
+class TestCandidateSelectorProtocolRuntimeCheckable:
+    """Positive compliance: isinstance checks for all implementations."""
+
+    def test_import_path_equivalence(self) -> None:
+        """CandidateSelectorProtocol is accessible from both import paths."""
+        from gepa_adk.ports import CandidateSelectorProtocol as from_init
+        from gepa_adk.ports.candidate_selector import (
+            CandidateSelectorProtocol as from_module,
+        )
+
+        assert from_init is from_module
+
+    def test_is_protocol_compliant(self, selector: CandidateSelectorProtocol) -> None:
+        """Selectors implement CandidateSelectorProtocol."""
+        assert isinstance(selector, CandidateSelectorProtocol)
 
 
-@pytest.mark.asyncio
-async def test_select_candidate_returns_valid_index(
-    selector: CandidateSelectorProtocol, pareto_state: ParetoState
-) -> None:
-    """select_candidate returns a valid candidate index."""
-    result = await selector.select_candidate(pareto_state)
-    assert 0 <= result < len(pareto_state.candidates)
+class TestCandidateSelectorProtocolBehavior:
+    """Behavioral expectations: return types, edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_select_candidate_returns_valid_index(
+        self, selector: CandidateSelectorProtocol, pareto_state: ParetoState
+    ) -> None:
+        """select_candidate returns a valid candidate index."""
+        result = await selector.select_candidate(pareto_state)
+        assert 0 <= result < len(pareto_state.candidates)
+
+    @pytest.mark.asyncio
+    async def test_select_candidate_returns_int(
+        self, selector: CandidateSelectorProtocol, pareto_state: ParetoState
+    ) -> None:
+        """select_candidate returns an int."""
+        result = await selector.select_candidate(pareto_state)
+        assert isinstance(result, int)
+
+    @pytest.mark.asyncio
+    async def test_select_candidate_raises_on_empty_state(
+        self, selector: CandidateSelectorProtocol, empty_state: ParetoState
+    ) -> None:
+        """select_candidate raises NoCandidateAvailableError for empty state."""
+        with pytest.raises(NoCandidateAvailableError):
+            await selector.select_candidate(empty_state)
 
 
-@pytest.mark.asyncio
-async def test_select_candidate_raises_on_empty_state(
-    selector: CandidateSelectorProtocol, empty_state: ParetoState
-) -> None:
-    """select_candidate raises NoCandidateAvailableError for empty state."""
-    with pytest.raises(NoCandidateAvailableError):
-        await selector.select_candidate(empty_state)
+class TestCandidateSelectorProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
+
+    def test_missing_method_not_isinstance(self) -> None:
+        """Class without select_candidate is not a CandidateSelectorProtocol."""
+
+        class Incomplete:
+            pass
+
+        assert not isinstance(Incomplete(), CandidateSelectorProtocol)
+
+    def test_runtime_checkable_limitation_documented(self) -> None:
+        """@runtime_checkable only checks method existence, not signatures."""
+
+        class WrongSignature:
+            async def select_candidate(self): ...
+
+        # isinstance passes because runtime_checkable doesn't check signatures
+        assert isinstance(WrongSignature(), CandidateSelectorProtocol)

--- a/tests/contracts/test_candidate_selector_protocol.py
+++ b/tests/contracts/test_candidate_selector_protocol.py
@@ -36,14 +36,14 @@ def empty_state() -> ParetoState:
 
 @pytest.fixture(
     params=[
-        ParetoCandidateSelector(random.Random(1)),
-        CurrentBestCandidateSelector(),
-        EpsilonGreedyCandidateSelector(epsilon=0.1, rng=random.Random(2)),
+        lambda: ParetoCandidateSelector(random.Random(1)),
+        lambda: CurrentBestCandidateSelector(),
+        lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=random.Random(2)),
     ]
 )
 def selector(request) -> CandidateSelectorProtocol:
     """Provide each selector implementation for contract tests."""
-    return request.param
+    return request.param()
 
 
 class TestCandidateSelectorProtocolRuntimeCheckable:

--- a/tests/contracts/test_component_selector_protocol.py
+++ b/tests/contracts/test_component_selector_protocol.py
@@ -4,51 +4,95 @@ from typing import Protocol
 
 import pytest
 
+from gepa_adk.adapters.selection.component_selector import (
+    AllComponentSelector,
+    RoundRobinComponentSelector,
+)
 from gepa_adk.ports import ComponentSelectorProtocol
 
 pytestmark = pytest.mark.contract
 
 
-def test_import_path_equivalence() -> None:
-    """ComponentSelectorProtocol is accessible from both import paths."""
-    from gepa_adk.ports import ComponentSelectorProtocol as from_init
-    from gepa_adk.ports.component_selector import (
-        ComponentSelectorProtocol as from_module,
-    )
+class TestComponentSelectorProtocolRuntimeCheckable:
+    """Positive compliance: isinstance checks for implementations."""
 
-    assert from_init is from_module
+    def test_import_path_equivalence(self) -> None:
+        """ComponentSelectorProtocol is accessible from both import paths."""
+        from gepa_adk.ports import ComponentSelectorProtocol as from_init
+        from gepa_adk.ports.component_selector import (
+            ComponentSelectorProtocol as from_module,
+        )
+
+        assert from_init is from_module
+
+    def test_is_protocol(self) -> None:
+        """ComponentSelectorProtocol is a Protocol."""
+        assert issubclass(ComponentSelectorProtocol, Protocol)
+
+    def test_is_runtime_checkable(self) -> None:
+        """ComponentSelectorProtocol supports isinstance checks."""
+
+        class ImplementsProtocol:
+            async def select_components(
+                self, components: list[str], iteration: int, candidate_idx: int
+            ) -> list[str]:
+                return []
+
+        assert isinstance(ImplementsProtocol(), ComponentSelectorProtocol)
+
+    def test_round_robin_selector_satisfies_protocol(self) -> None:
+        """RoundRobinComponentSelector satisfies ComponentSelectorProtocol."""
+        selector = RoundRobinComponentSelector()
+        assert isinstance(selector, ComponentSelectorProtocol)
+
+    def test_all_component_selector_satisfies_protocol(self) -> None:
+        """AllComponentSelector satisfies ComponentSelectorProtocol."""
+        selector = AllComponentSelector()
+        assert isinstance(selector, ComponentSelectorProtocol)
 
 
-def test_component_selector_protocol_is_protocol() -> None:
-    """Test that ComponentSelectorProtocol is a Protocol."""
-    assert issubclass(ComponentSelectorProtocol, Protocol)
+class TestComponentSelectorProtocolBehavior:
+    """Behavioral expectations: return types, method contracts."""
+
+    @pytest.mark.asyncio
+    async def test_select_components_returns_list(self) -> None:
+        """select_components returns a list of strings."""
+        selector = AllComponentSelector()
+        result = await selector.select_components(
+            components=["instruction", "schema"], iteration=0, candidate_idx=0
+        )
+        assert isinstance(result, list)
+        for item in result:
+            assert isinstance(item, str)
+
+    @pytest.mark.asyncio
+    async def test_select_components_returns_subset(self) -> None:
+        """select_components returns a subset of the input components."""
+        selector = RoundRobinComponentSelector()
+        components = ["instruction", "schema", "examples"]
+        result = await selector.select_components(
+            components=components, iteration=0, candidate_idx=0
+        )
+        assert all(c in components for c in result)
 
 
-def test_component_selector_protocol_is_runtime_checkable() -> None:
-    """Test that ComponentSelectorProtocol supports isinstance checks."""
+class TestComponentSelectorProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
 
-    class ImplementsProtocol:
-        async def select_components(
-            self, components: list[str], iteration: int, candidate_idx: int
-        ) -> list[str]:
-            return []
+    def test_missing_method_not_isinstance(self) -> None:
+        """Class without select_components fails isinstance check."""
 
-    assert isinstance(ImplementsProtocol(), ComponentSelectorProtocol)
+        class MissingMethod:
+            pass
 
+        assert not isinstance(MissingMethod(), ComponentSelectorProtocol)
 
-def test_component_selector_protocol_rejects_incomplete_implementation() -> None:
-    """Test that incomplete implementation fails isinstance check."""
+    def test_runtime_checkable_limitation_documented(self) -> None:
+        """@runtime_checkable only checks method existence, not signatures."""
 
-    class MissingMethod:
-        pass
+        class WrongSignature:
+            async def select_components(self, components: list[str]) -> list[str]:
+                return []
 
-    assert not isinstance(MissingMethod(), ComponentSelectorProtocol)
-
-    class WrongSignature:
-        # Missing arguments
-        async def select_components(self, components: list[str]) -> list[str]:
-            return []
-
-    # Note: runtime_checkable only checks for presence of method, not signature compatibility
-    # so we only test method presence here
-    assert isinstance(WrongSignature(), ComponentSelectorProtocol)
+        # runtime_checkable only checks for presence of method, not signature
+        assert isinstance(WrongSignature(), ComponentSelectorProtocol)

--- a/tests/contracts/test_merge_proposer_protocol.py
+++ b/tests/contracts/test_merge_proposer_protocol.py
@@ -117,3 +117,24 @@ class TestMergeProposerProtocol:
 
         assert state.candidates == original_candidates
         assert state.candidate_scores == original_scores
+
+
+class TestMergeProposerProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
+
+    def test_missing_propose_not_isinstance(self) -> None:
+        """Class without propose method is not a ProposerProtocol."""
+
+        class Incomplete:
+            pass
+
+        assert not isinstance(Incomplete(), ProposerProtocol)
+
+    def test_runtime_checkable_limitation_documented(self) -> None:
+        """@runtime_checkable only checks method existence, not signatures."""
+
+        class WrongSignature:
+            async def propose(self): ...
+
+        # isinstance passes because runtime_checkable doesn't check signatures
+        assert isinstance(WrongSignature(), ProposerProtocol)

--- a/tests/contracts/test_multi_agent_adapter_protocol.py
+++ b/tests/contracts/test_multi_agent_adapter_protocol.py
@@ -90,7 +90,7 @@ class TestMultiAgentAdapterProtocolRuntimeCheckable:
 
 
 class TestMultiAgentAdapterProtocolBehavior:
-    """Behavioral expectations: async methods, return types, constructor validation."""
+    """Behavioral expectations: async protocol methods on MultiAgentAdapter."""
 
     def test_evaluate_is_async(self, adapter: MultiAgentAdapter) -> None:
         """Evaluate is an async method."""

--- a/tests/contracts/test_multi_agent_adapter_protocol.py
+++ b/tests/contracts/test_multi_agent_adapter_protocol.py
@@ -2,13 +2,11 @@
 
 These tests verify that MultiAgentAdapter correctly implements the AsyncGEPAAdapter
 protocol with proper method signatures, return types, and behavior contracts.
-
-Note:
-    Contract tests focus on protocol compliance, not business logic.
-    They ensure the adapter can be used by the evolution engine.
 """
 
 from __future__ import annotations
+
+import inspect
 
 import pytest
 from google.adk.agents import LlmAgent
@@ -77,32 +75,34 @@ def adapter(
     )
 
 
-class TestMultiAgentAdapterProtocolCompliance:
-    """Contract tests verifying MultiAgentAdapter implements AsyncGEPAAdapter protocol.
+class TestMultiAgentAdapterProtocolRuntimeCheckable:
+    """Positive compliance: isinstance checks for MultiAgentAdapter."""
 
-    Note:
-        These tests ensure the adapter can be used by the evolution engine
-        without testing the full implementation logic.
-    """
+    def test_adapter_satisfies_protocol(self, adapter: MultiAgentAdapter) -> None:
+        """MultiAgentAdapter instance checks as AsyncGEPAAdapter."""
+        assert isinstance(adapter, AsyncGEPAAdapter)
 
     def test_adapter_has_required_methods(self, adapter: MultiAgentAdapter) -> None:
-        """Verify MultiAgentAdapter has all required protocol methods."""
+        """MultiAgentAdapter has all required protocol methods."""
         assert hasattr(adapter, "evaluate")
         assert hasattr(adapter, "make_reflective_dataset")
         assert hasattr(adapter, "propose_new_texts")
 
-    def test_adapter_methods_are_async(self, adapter: MultiAgentAdapter) -> None:
-        """Verify all adapter methods are coroutines."""
-        import inspect
 
+class TestMultiAgentAdapterProtocolBehavior:
+    """Behavioral expectations: async methods, return types, constructor validation."""
+
+    def test_evaluate_is_async(self, adapter: MultiAgentAdapter) -> None:
+        """Evaluate is an async method."""
         assert inspect.iscoroutinefunction(adapter.evaluate)
-        assert inspect.iscoroutinefunction(adapter.make_reflective_dataset)
-        assert inspect.iscoroutinefunction(adapter.propose_new_texts)
 
-    def test_adapter_satisfies_protocol(self, adapter: MultiAgentAdapter) -> None:
-        """Verify MultiAgentAdapter instance checks as AsyncGEPAAdapter."""
-        # Protocol is runtime_checkable, so isinstance should work
-        assert isinstance(adapter, AsyncGEPAAdapter)
+    def test_make_reflective_dataset_is_async(self, adapter: MultiAgentAdapter) -> None:
+        """make_reflective_dataset is an async method."""
+        assert inspect.iscoroutinefunction(adapter.make_reflective_dataset)
+
+    def test_propose_new_texts_is_async(self, adapter: MultiAgentAdapter) -> None:
+        """propose_new_texts is an async method."""
+        assert inspect.iscoroutinefunction(adapter.propose_new_texts)
 
     def test_constructor_validates_agents_dict(
         self,
@@ -110,7 +110,7 @@ class TestMultiAgentAdapterProtocolCompliance:
         mock_scorer: MockScorer,
         mock_proposer: AsyncReflectiveMutationProposer,
     ) -> None:
-        """Ensure constructor rejects empty agents dict."""
+        """Constructor rejects empty agents dict."""
         from gepa_adk.domain.exceptions import MultiAgentValidationError
 
         with pytest.raises(
@@ -123,3 +123,48 @@ class TestMultiAgentAdapterProtocolCompliance:
                 scorer=mock_scorer,
                 proposer=mock_proposer,
             )
+
+
+class TestMultiAgentAdapterProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
+
+    def test_missing_all_methods_not_isinstance(self) -> None:
+        """Class without any protocol methods is not an AsyncGEPAAdapter."""
+
+        class Incomplete:
+            pass
+
+        assert not isinstance(Incomplete(), AsyncGEPAAdapter)
+
+    def test_missing_evaluate_not_isinstance(self) -> None:
+        """Class missing evaluate is not an AsyncGEPAAdapter."""
+
+        class MissingEvaluate:
+            async def make_reflective_dataset(self, *a, **kw): ...
+
+            async def propose_new_texts(self, *a, **kw): ...
+
+        assert not isinstance(MissingEvaluate(), AsyncGEPAAdapter)
+
+    def test_missing_propose_not_isinstance(self) -> None:
+        """Class missing propose_new_texts is not an AsyncGEPAAdapter."""
+
+        class MissingPropose:
+            async def evaluate(self, *a, **kw): ...
+
+            async def make_reflective_dataset(self, *a, **kw): ...
+
+        assert not isinstance(MissingPropose(), AsyncGEPAAdapter)
+
+    def test_runtime_checkable_limitation_documented(self) -> None:
+        """@runtime_checkable only checks method existence, not signatures."""
+
+        class WrongSignature:
+            async def evaluate(self): ...
+
+            async def make_reflective_dataset(self): ...
+
+            async def propose_new_texts(self): ...
+
+        # isinstance passes because runtime_checkable doesn't check signatures
+        assert isinstance(WrongSignature(), AsyncGEPAAdapter)

--- a/tests/contracts/test_multi_agent_adapter_protocol.py
+++ b/tests/contracts/test_multi_agent_adapter_protocol.py
@@ -104,26 +104,6 @@ class TestMultiAgentAdapterProtocolBehavior:
         """propose_new_texts is an async method."""
         assert inspect.iscoroutinefunction(adapter.propose_new_texts)
 
-    def test_constructor_validates_agents_dict(
-        self,
-        mock_components: dict[str, list[str]],
-        mock_scorer: MockScorer,
-        mock_proposer: AsyncReflectiveMutationProposer,
-    ) -> None:
-        """Constructor rejects empty agents dict."""
-        from gepa_adk.domain.exceptions import MultiAgentValidationError
-
-        with pytest.raises(
-            MultiAgentValidationError, match="agents dict cannot be empty"
-        ):
-            MultiAgentAdapter(
-                agents={},
-                primary="generator",
-                components=mock_components,
-                scorer=mock_scorer,
-                proposer=mock_proposer,
-            )
-
 
 class TestMultiAgentAdapterProtocolNonCompliance:
     """Negative cases: objects missing required methods are not instances."""
@@ -155,6 +135,16 @@ class TestMultiAgentAdapterProtocolNonCompliance:
             async def make_reflective_dataset(self, *a, **kw): ...
 
         assert not isinstance(MissingPropose(), AsyncGEPAAdapter)
+
+    def test_missing_make_reflective_dataset_not_isinstance(self) -> None:
+        """Class missing make_reflective_dataset is not an AsyncGEPAAdapter."""
+
+        class MissingReflective:
+            async def evaluate(self, *a, **kw): ...
+
+            async def propose_new_texts(self, *a, **kw): ...
+
+        assert not isinstance(MissingReflective(), AsyncGEPAAdapter)
 
     def test_runtime_checkable_limitation_documented(self) -> None:
         """@runtime_checkable only checks method existence, not signatures."""

--- a/tests/contracts/test_proposer_protocol.py
+++ b/tests/contracts/test_proposer_protocol.py
@@ -186,3 +186,24 @@ class TestProposerProtocol:
         assert result is not None
         if result.tag == "merge":
             assert len(result.parent_indices) == 2
+
+
+class TestProposerProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
+
+    def test_missing_propose_not_isinstance(self) -> None:
+        """Class without propose method is not a ProposerProtocol."""
+
+        class Incomplete:
+            pass
+
+        assert not isinstance(Incomplete(), ProposerProtocol)
+
+    def test_runtime_checkable_limitation_documented(self) -> None:
+        """@runtime_checkable only checks method existence, not signatures."""
+
+        class WrongSignature:
+            async def propose(self): ...
+
+        # isinstance passes because runtime_checkable doesn't check signatures
+        assert isinstance(WrongSignature(), ProposerProtocol)

--- a/tests/contracts/test_video_blob_service_protocol.py
+++ b/tests/contracts/test_video_blob_service_protocol.py
@@ -218,3 +218,34 @@ class TestVideoBlobServiceRealImplementation:
             await service.prepare_video_parts(["/nonexistent/video.mp4"])
 
         assert exc_info.value.video_path == "/nonexistent/video.mp4"
+
+
+class TestVideoBlobServiceProtocolNonCompliance:
+    """Negative cases: objects missing required methods are not instances."""
+
+    def test_missing_all_methods_not_isinstance(self) -> None:
+        """Class without any protocol methods is not a VideoBlobServiceProtocol."""
+
+        class Incomplete:
+            pass
+
+        assert not isinstance(Incomplete(), VideoBlobServiceProtocol)
+
+    def test_missing_prepare_video_parts_not_isinstance(self) -> None:
+        """Class missing prepare_video_parts is not a VideoBlobServiceProtocol."""
+
+        class MissingPrepare:
+            def validate_video_file(self, video_path: str): ...
+
+        assert not isinstance(MissingPrepare(), VideoBlobServiceProtocol)
+
+    def test_runtime_checkable_limitation_documented(self) -> None:
+        """@runtime_checkable only checks method existence, not signatures."""
+
+        class WrongSignature:
+            async def prepare_video_parts(self): ...
+
+            def validate_video_file(self): ...
+
+        # isinstance passes because runtime_checkable doesn't check signatures
+        assert isinstance(WrongSignature(), VideoBlobServiceProtocol)

--- a/uv.lock
+++ b/uv.lock
@@ -493,14 +493,14 @@ wheels = [
 
 [[package]]
 name = "docvet"
-version = "1.7.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/e7/cde9e080a634538cf1375c07d97898611e8053178b548b5730702bb09063/docvet-1.7.0.tar.gz", hash = "sha256:359cd5b1c43c463af53aa12f9d5b5e06f971ae24612a0b60ef39db81c5b48c03", size = 49228, upload-time = "2026-03-03T04:15:08.096Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/4e/3503462bc15263ad1a744ad2e5bff3d38d50797a1b2999e6475d9a83f776/docvet-1.11.0.tar.gz", hash = "sha256:510fba480650c3ee7201f3fb99be89f25a08cf87e3331810ce3963a1ca14158a", size = 56088, upload-time = "2026-03-07T00:03:19.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/59/bebb2901484a0e31262cb4378cce27ea96a33571d8a06d33341eeb4a8393/docvet-1.7.0-py3-none-any.whl", hash = "sha256:5116b8495df8901ec2bbe11ac98a0f2de6cff0d2779c705e63a01d70be02c1fb", size = 56484, upload-time = "2026-03-03T04:15:08.978Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3d/11edadce56d90563ea56dd9237253b1b00e539ea34b8ec54864c24286b11/docvet-1.11.0-py3-none-any.whl", hash = "sha256:c00069ae752e259480bf36624e3f03828fbcbc4fa0e0f9e8fbd29b8a30456f03", size = 64527, upload-time = "2026-03-07T00:03:20.502Z" },
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ requires-dist = [
 dev = [
     { name = "arize-phoenix-client" },
     { name = "cairosvg", specifier = ">=2.7.1" },
-    { name = "docvet", specifier = ">=1.7.0" },
+    { name = "docvet", specifier = ">=1.11.0" },
     { name = "gepa", specifier = ">=0.0.24" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.1.2" },
     { name = "griffe-warnings-deprecated", specifier = ">=1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -226,6 +226,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +516,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/3d/11edadce56d90563ea56dd9237253b1b00e539ea34b8ec54864c24286b11/docvet-1.11.0-py3-none-any.whl", hash = "sha256:c00069ae752e259480bf36624e3f03828fbcbc4fa0e0f9e8fbd29b8a30456f03", size = 64527, upload-time = "2026-03-07T00:03:20.502Z" },
 ]
 
+[package.optional-dependencies]
+lsp = [
+    { name = "pygls" },
+]
+mcp = [
+    { name = "mcp" },
+]
+
 [[package]]
 name = "email-validator"
 version = "2.3.0"
@@ -670,7 +691,7 @@ dependencies = [
 dev = [
     { name = "arize-phoenix-client" },
     { name = "cairosvg" },
-    { name = "docvet" },
+    { name = "docvet", extra = ["lsp", "mcp"] },
     { name = "gepa" },
     { name = "griffe-inherited-docstrings" },
     { name = "griffe-warnings-deprecated" },
@@ -713,7 +734,7 @@ requires-dist = [
 dev = [
     { name = "arize-phoenix-client" },
     { name = "cairosvg", specifier = ">=2.7.1" },
-    { name = "docvet", specifier = ">=1.11.0" },
+    { name = "docvet", extras = ["lsp", "mcp"], specifier = ">=1.11.0" },
     { name = "gepa", specifier = ">=0.0.24" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.1.2" },
     { name = "griffe-warnings-deprecated", specifier = ">=1.1.0" },
@@ -1707,6 +1728,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/ab/4fe5517ac55f72ca90119cd0d894a7b4e394ae76e1ccdeb775bd50154b0d/litellm-1.81.14.tar.gz", hash = "sha256:445efb92ae359e8f40ee984753c5ae752535eb18a2aeef00d3089922de5676b7", size = 16541822, upload-time = "2026-02-22T00:33:35.281Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/b3/e8fe151c1b81666575552835a3a79127c5aa6bd460fcecc51e032d2f4019/litellm-1.81.14-py3-none-any.whl", hash = "sha256:6394e61bbdef7121e5e3800349f6b01e9369e7cf611e034f1832750c481abfed", size = 14603260, upload-time = "2026-02-22T00:33:32.464Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -2749,6 +2783,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/94/cce3560f6c7296be43bd67ba342f8972b8adddfe407b62b25d1fb90c514b/pygls-2.0.1.tar.gz", hash = "sha256:2f774a669fbe2ece977d302786f01f9b0c5df7d0204ea0fa371ecb08288d6b86", size = 55796, upload-time = "2026-01-26T23:04:33.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl", hash = "sha256:d29748042cea5bedc98285eb3e2c0c60bf3fc73786319519001bf72bbe8f36cc", size = 69536, upload-time = "2026-01-26T23:04:35.197Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Contract test files had inconsistent coverage: 3 files used bare functions instead of the three-class template, and 3 files lacked non-compliance tests entirely. This brings all protocol contract tests to the minimum 4 test types (isinstance, signature verification, behavioral, non-compliance). Additionally resolves all 41 docvet findings codebase-wide and upgrades docvet to v1.11.0.

- Upgrade `test_candidate_selector_protocol.py`, `test_component_selector_protocol.py`, and `test_multi_agent_adapter_protocol.py` to three-class template (RuntimeCheckable, Behavior, NonCompliance)
- Add non-compliance tests to `test_proposer_protocol.py`, `test_merge_proposer_protocol.py`, and `test_video_blob_service_protocol.py`
- Fix shared mutable RNG state in candidate selector fixture with factory lambdas
- Contract test count increased from 430 to 453 with zero regressions

Test: `uv run pytest tests/contracts/ -x` (453 passed)

fix(contracts): address code review findings in protocol contract tests

- Fix shared mutable RNG state in candidate_selector fixture with factory lambdas
- Remove misplaced constructor validation test (already covered in unit tier)
- Add missing make_reflective_dataset non-compliance test for AsyncGEPAAdapter

docs(docstrings): resolve all 41 docvet findings and upgrade to v1.11.0

- Add See Also cross-references to 22 module docstrings using mkdocstrings format
- Add Examples sections to 8 module docstrings missing usage examples
- Add Raises sections to 3 functions in domain/state.py (required findings)
- Fix typed Attributes format in ParetoFrontier, ParetoState, ExecutionStatus
- Upgrade docvet from 1.7.0 to 1.11.0 with lsp and mcp extras
- Add .mcp.json with docvet MCP server configuration

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Three upgraded test files serve as exemplars for the three-class template pattern. Docstring additions are formulaic (See Also, Examples, Raises sections) — verify cross-reference paths are accurate.

### Related
Story 3.2 in Epic 3 (Evolution Control & Extensibility)