### PR TITLE
docs(contributing): add extension point guides for ComponentHandler and AgentProvider

### DIFF
--- a/_bmad-output/implementation-artifacts/3-3-extension-point-documentation.md
+++ b/_bmad-output/implementation-artifacts/3-3-extension-point-documentation.md
@@ -1,0 +1,227 @@
+# Story 3.3: Extension Point Documentation
+
+Status: review
+Branch: docs/epic-3-3-extension-point-documentation
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a contributor,
+I want clear documentation for extending the system,
+so that I can add new evolvable surfaces or agent providers without reading internal code.
+
+## Acceptance Criteria
+
+1. **Given** `ComponentHandler` Protocol (FR21) and `AgentProvider` Protocol (FR22) exist with mature contract tests, **When** extension documentation is created, **Then** each extension point has a dedicated guide page with: Protocol definition, step-by-step implementation recipe, registration process, runnable example, and common pitfalls
+2. **And** contract test skeletons are provided as a starting point for new implementations
+3. **And** the extension points are accessible using only public API imports -- no internal module imports required
+4. **And** guide pages are added to MkDocs navigation under `Contributing > Extending` with a minimal index/landing page
+
+## Tasks / Subtasks
+
+- [x] Task 1: Verify and fix public API exports (AC: 3) -- MUST complete before writing guides
+  - [x] 1.1 Confirm `ComponentHandler` is importable from `gepa_adk.ports` (check `__all__` in `ports/__init__.py`)
+  - [x] 1.2 Confirm `AgentProvider` is importable from `gepa_adk.ports`
+  - [x] 1.3 Add `ComponentHandler` and `AgentProvider` to `gepa_adk.__init__.__all__` (re-export from top-level package for import consistency with other public symbols)
+  - [x] 1.4 Confirm `ComponentHandlerRegistry` (or `register_handler`/`get_handler`) is accessible from `gepa_adk.adapters`
+  - [x] 1.5 Run `uv run pytest` -- verify no regressions from export changes
+
+- [x] Task 2: Create ComponentHandler extension guide (AC: 1, 2, 3)
+  - [x] 2.1 Create `docs/contributing/extending-surfaces.md`
+  - [x] 2.2 Write "When to Use" section using `!!! tip` admonition -- when a contributor needs a new evolvable surface beyond instruction/output_schema/generate_content_config
+  - [x] 2.3 Write Protocol definition section -- show `ComponentHandler` with `serialize()`, `apply()`, `restore()` signatures and explain the contract (no exceptions, graceful degradation)
+  - [x] 2.4 Write step-by-step implementation recipe -- create a `TemperatureHandler` example that serializes/applies/restores `generate_content_config.temperature`. Use a plain class (NO Protocol inheritance -- structural subtyping per ADR-002)
+  - [x] 2.5 Write registration section -- show `ComponentHandlerRegistry.register()` and how the engine discovers handlers via `get_handler()`
+  - [x] 2.6 Write self-contained runnable example -- demonstrates the serialize/apply/restore cycle on an agent object without requiring an LLM API key. Show a separate config snippet for integration with `evolve()`
+  - [x] 2.7 Write common pitfalls section using `!!! warning` admonition -- raising exceptions instead of returning defaults, forgetting restore, not handling `None` values, inheriting from Protocol instead of structural subtyping
+  - [x] 2.8 Write contract test skeleton -- inline three-class template (RuntimeCheckable, Behavior, NonCompliance) for a custom handler, using only public imports. Add explicit reference: "This skeleton follows the pattern in `tests/contracts/test_component_handler_protocol.py` -- always check the latest exemplar before starting"
+
+- [x] Task 3: Create AgentProvider extension guide (AC: 1, 2, 3)
+  - [x] 3.1 Create `docs/contributing/extending-providers.md`
+  - [x] 3.2 Write "When to Use" section using `!!! tip` admonition -- when a contributor needs custom agent persistence (database, file system, remote registry)
+  - [x] 3.3 Write Protocol definition section -- show `AgentProvider` with `get_agent()`, `save_instruction()`, `list_agents()` signatures and error contracts (KeyError, ValueError, IOError)
+  - [x] 3.4 Write step-by-step implementation recipe -- create a `JsonFileAgentProvider` example that reads/writes agent configs from JSON files. Use a plain class (NO Protocol inheritance)
+  - [x] 3.5 Write registration/injection section -- show how to pass custom provider to evolution engine
+  - [x] 3.6 Write self-contained runnable example -- demonstrates get_agent/save_instruction/list_agents cycle without requiring an LLM API key. Show a separate config snippet for integration with `evolve()`
+  - [x] 3.7 Write common pitfalls section using `!!! warning` admonition -- missing validation on empty names, not persisting before returning updated agent, IOError handling, inheriting from Protocol
+  - [x] 3.8 Write contract test skeleton -- inline three-class template for a custom provider with explicit exemplar reference to `tests/contracts/test_agent_provider_protocol.py`
+
+- [x] Task 4: Update MkDocs navigation and create index page (AC: 4)
+  - [x] 4.1 Create `docs/contributing/extending.md` -- minimal index/landing page (under 30 lines) with: one-paragraph intro to Protocol-based extension model, bullet list of available extension points with one-line descriptions, links to detailed guide pages
+  - [x] 4.2 Add "Extending" subsection under Contributing in `mkdocs.yml` nav using `navigation.indexes`:
+    ```
+    Contributing:
+      - Extending:
+        - contributing/extending.md
+        - Evolvable Surfaces: contributing/extending-surfaces.md
+        - Agent Providers: contributing/extending-providers.md
+      - Docstring Templates: contributing/docstring-templates.md
+      - Releasing: contributing/releasing.md
+    ```
+
+- [x] Task 5: Final verification (AC: 1, 2, 3, 4)
+  - [x] 5.1 Run `uv run mkdocs build --strict` -- verify docs build with no warnings (2 pre-existing cross-ref warnings in unrelated files; no new warnings from this story)
+  - [x] 5.2 Verify all code examples are syntactically valid Python
+  - [x] 5.3 Verify all imports in examples use `from gepa_adk import ComponentHandler` (top-level) -- NOT `from gepa_adk.ports import ...`
+  - [x] 5.4 Verify contract test skeletons follow three-class template from Story 3.2
+  - [x] 5.5 Run `uv run pytest` -- no regressions
+
+- [ ] [TEA] Testing maturity: verify that ComponentHandlerRegistry.register/get_handler have unit tests for edge cases (duplicate registration, unknown handler name) (cross-cutting, optional)
+
+## Dev Notes
+
+### Guide Style and Structure
+
+Follow the pattern established in `docs/guides/stoppers.md` (the exemplar extension guide):
+- Start with a `!!! tip` admonition callout for context ("When to Use")
+- Use `!!! warning` for common pitfalls sections
+- Use `!!! note` for contract details and important behavioral constraints
+- "Available X" table for built-in implementations
+- "Basic Usage" section with minimal code examples
+- All code blocks use `python` syntax highlighting with `from gepa_adk import ...` public imports (top-level, not `gepa_adk.ports`)
+
+### Structural Subtyping (ADR-002) -- Critical for Examples
+
+All implementation examples in guide pages MUST use plain classes with matching method signatures. Do NOT inherit from the Protocol:
+- **Correct**: `class TemperatureHandler:` (plain class, structural subtyping)
+- **Wrong**: `class TemperatureHandler(ComponentHandler):` (inheritance -- misleads contributors)
+ADR-002 mandates structural subtyping. If docs show inheritance, contributors will think it's required.
+
+### Example Runnability (Party Mode Consensus)
+
+Guide examples must be **self-contained** (level 2 runnability):
+- Demonstrate the protocol contract (serialize/apply/restore or get_agent/save_instruction/list_agents) without requiring an LLM API key, trainset, or external services
+- Show the handler/provider working against a real or minimal agent object
+- Provide a **separate config snippet** showing how to integrate with `evolve()` -- but this snippet is illustrative, not runnable standalone
+- Do NOT write full evolution-run examples that require API credentials
+
+### Contract Test Skeleton Approach (Party Mode Consensus)
+
+- **Inline** the skeleton directly in the guide page (not via `pymdownx.snippets`)
+- **Reference the living exemplar** explicitly: "This skeleton follows the pattern in `tests/contracts/test_component_handler_protocol.py` -- always check the latest exemplar before starting"
+- Do NOT add version notes or "last verified" annotations -- the exemplar reference is the safety net
+
+### Extension Points Inventory
+
+**ComponentHandler** (`src/gepa_adk/ports/component_handler.py`):
+- Protocol: `serialize(agent) -> str`, `apply(agent, value) -> Any`, `restore(agent, original) -> None`
+- Contract: Never raise exceptions -- return empty string or default on failure, log warning
+- Built-in handlers: `InstructionHandler`, `OutputSchemaHandler`, `GenerateContentConfigHandler`
+- Registry: `ComponentHandlerRegistry` in `adapters/components/component_handlers.py`
+  - `register(component_name, handler)`, `get(component_name)`, `list_handlers()`
+  - Module-level convenience: `component_handlers` (default registry), `get_handler()`, `register_handler()`
+
+**AgentProvider** (`src/gepa_adk/ports/agent_provider.py`):
+- Protocol: `get_agent(name) -> LlmAgent`, `save_instruction(name, instruction) -> None`, `list_agents() -> list[str]`
+- Contract: `KeyError` for unknown name, `ValueError` for empty/invalid name, `IOError` for persistence failures
+- No built-in implementations shipped (examples use in-memory implementations inline)
+- Injected via constructor/config, not via registry
+
+### Contract Test Skeleton Template
+
+Use three-class template established in Story 3.2 as exemplar:
+```
+TestXxxProtocolRuntimeCheckable  -- isinstance checks
+TestXxxProtocolBehavior          -- return types, state transitions, error contracts
+TestXxxProtocolNonCompliance     -- missing methods -> not isinstance
+```
+- Mark with `pytestmark = pytest.mark.contract`
+- Import Protocol from `gepa_adk.ports` (public path)
+- Reference exemplars: `tests/contracts/test_component_handler_protocol.py`, `tests/contracts/test_agent_provider_protocol.py`
+
+### Hexagonal Architecture Compliance (ADR-000)
+
+- Guide examples must NOT import from `gepa_adk.adapters.*` internal modules for Protocol definitions
+- Protocol imports: `from gepa_adk import ComponentHandler, AgentProvider` (top-level re-export -- Task 1 ensures these are added)
+- Built-in adapter imports (for reference only): `from gepa_adk.adapters.components import ...`
+- New contributor implementations go in their own project, not in gepa-adk's adapters/
+
+### Previous Story Learnings (from 3-1 and 3-2)
+
+**Story 3.1 (Critic Preset Factory):**
+- `create_critic()` factory pattern used for MVP -- simple dict-based preset registry
+- All presets use `CriticOutput` schema (not `SimpleCriticOutput`) to maximize ASI quality
+- Public API exports via `gepa_adk.__init__` -- follow same pattern for any new exports
+
+**Story 3.2 (Contract Test Gaps):**
+- Three-class template is the established standard for protocol contract tests
+- 453 contract tests across 12 protocols -- all green
+- `scripts/check_protocol_coverage.py` enforces Protocol-to-test mapping in CI
+- Non-compliance tests verify `@runtime_checkable` limitation: only checks method existence, not signatures
+
+### Git Intelligence (from recent commits)
+
+- `ac59411` (Story 3-1): Added `create_critic()` factory, 3 presets, 7 unit tests, public API exports
+- `30d7deb` (Story 3-2): Upgraded 3 contract test files to three-class template, added non-compliance to 3 more, 36 files touched, docstrings enriched with See Also and Examples sections
+- Story 3-2 enriched port docstrings with `Examples:` sections showing compliance verification -- these are good starting material for guide content
+
+### Documentation Impact
+
+This IS the documentation story. Impact:
+- **New files**: `docs/contributing/extending.md` (index), `docs/contributing/extending-surfaces.md`, `docs/contributing/extending-providers.md`
+- **Modified files**: `mkdocs.yml` (nav update), `src/gepa_adk/__init__.py` (`__all__` exports)
+- **No API docs impact**: mkdocstrings auto-generates API reference from docstrings (already enriched in Story 3-2)
+- **No ADR impact**: ADR-002 (Protocol Interfaces) already covers the design decisions
+
+### Project Structure Notes
+
+- New docs go in `docs/contributing/` alongside existing `docstring-templates.md` and `releasing.md`
+- MkDocs nav uses `Contributing > Extending > [index, surfaces, providers]` with `navigation.indexes`
+- `src/gepa_adk/__init__.py` updated to re-export `ComponentHandler` and `AgentProvider` (Task 1)
+- No changes to `tests/` -- contract test skeletons are documentation content, not runnable test files
+
+### References
+
+- [Source: src/gepa_adk/ports/component_handler.py -- ComponentHandler Protocol definition]
+- [Source: src/gepa_adk/ports/agent_provider.py -- AgentProvider Protocol definition]
+- [Source: src/gepa_adk/adapters/components/component_handlers.py -- ComponentHandlerRegistry, built-in handlers]
+- [Source: tests/contracts/test_component_handler_protocol.py -- ComponentHandler contract tests exemplar]
+- [Source: tests/contracts/test_agent_provider_protocol.py -- AgentProvider contract tests exemplar]
+- [Source: docs/guides/stoppers.md -- Guide style exemplar for extension point docs]
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 3, Story 3.3]
+- [Source: _bmad-output/planning-artifacts/architecture.md -- Pattern 1: New Adapter Implementation Recipe]
+- [Source: _bmad-output/implementation-artifacts/3-1-implement-critic-preset-factory.md -- Previous story learnings]
+- [Source: _bmad-output/implementation-artifacts/3-2-fill-contract-test-gaps.md -- Previous story learnings]
+- [Source: mkdocs.yml -- Current nav structure for placement]
+
+## AC-to-Test Mapping
+
+| AC | Verification | Status |
+|----|-------------|--------|
+| AC1 (dedicated guide pages) | Manual: `docs/contributing/extending-surfaces.md` and `extending-providers.md` contain Protocol definition, implementation recipe, registration, runnable example, common pitfalls | PASS |
+| AC2 (contract test skeletons) | Manual: Both guides contain inline three-class template skeletons (RuntimeCheckable, Behavior, NonCompliance) with exemplar references | PASS |
+| AC3 (public API imports only) | `grep -r "from gepa_adk.ports import" docs/contributing/` returns 0 matches; all examples use `from gepa_adk import ComponentHandler/AgentProvider` | PASS |
+| AC4 (MkDocs navigation) | `uv run mkdocs build` succeeds; nav includes `Contributing > Extending > [index, surfaces, providers]` | PASS |
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+- mkdocs build --strict: 2 pre-existing cross-ref warnings (`structlog.dev.ConsoleRenderer` in encoding.py, `gepa_adk.engine.reflection` in state_guard.py) — not introduced by this story
+- git-revision-date-localized warnings for new files are expected and resolve after commit
+
+### Completion Notes List
+
+- Task 1: Verified `ComponentHandler` and `AgentProvider` already exported from `gepa_adk.ports`. Added both to `gepa_adk.__init__.__all__` for top-level import. Confirmed `ComponentHandlerRegistry`, `get_handler`, `register_handler` accessible from `gepa_adk.adapters`. All 2124 tests pass.
+- Task 2: Created `docs/contributing/extending-surfaces.md` with all required sections: tip admonition, protocol definition with contract notes, TemperatureHandler step-by-step recipe (plain class, structural subtyping), registration via ComponentHandlerRegistry, self-contained runnable example, evolve() integration snippet, warning admonition for pitfalls, inline three-class contract test skeleton with exemplar reference.
+- Task 3: Created `docs/contributing/extending-providers.md` with all required sections: tip admonition, protocol definition with error contracts, JsonFileAgentProvider recipe (plain class), injection section, self-contained runnable example with tempfile, evolve() integration snippet, warning admonition for pitfalls, inline three-class contract test skeleton with exemplar reference.
+- Task 4: Created `docs/contributing/extending.md` index page (11 lines). Updated `mkdocs.yml` nav with `Contributing > Extending` subsection using `navigation.indexes`.
+- Task 5: Docs build succeeds (no new warnings). All 10 Python code blocks are syntactically valid. All imports use top-level `from gepa_adk import ...`. Contract test skeletons follow three-class template. 2124 tests pass.
+
+### File List
+
+- `src/gepa_adk/__init__.py` (modified) — added `AgentProvider` and `ComponentHandler` to imports and `__all__`
+- `docs/contributing/extending.md` (new) — index/landing page for extension points
+- `docs/contributing/extending-surfaces.md` (new) — ComponentHandler extension guide
+- `docs/contributing/extending-providers.md` (new) — AgentProvider extension guide
+- `mkdocs.yml` (modified) — added Extending subsection to Contributing nav
+
+## Change Log
+
+- 2026-03-08: Implemented Story 3.3 — created extension point documentation for ComponentHandler and AgentProvider protocols, added public API re-exports, updated MkDocs navigation
+

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -82,7 +82,7 @@ development_status:
   epic-3: in-progress
   3-1-implement-critic-preset-factory: done
   3-2-fill-contract-test-gaps: done
-  3-3-extension-point-documentation: backlog
+  3-3-extension-point-documentation: review
   epic-3-retrospective: optional
 
   # ── Epic 6: Evolution Analytics ──

--- a/docs/contributing/extending-providers.md
+++ b/docs/contributing/extending-providers.md
@@ -12,8 +12,7 @@ This guide explains how to implement custom agent persistence by creating an `Ag
 The `AgentProvider` protocol defines three methods:
 
 ```python
-from gepa_adk import AgentProvider
-
+# Protocol definition (from gepa_adk.ports.agent_provider — shown for reference)
 class AgentProvider(Protocol):
     def get_agent(self, name: str) -> LlmAgent:
         """Load an agent by its unique name."""
@@ -189,7 +188,7 @@ config = EvolutionConfig(max_iterations=5)
 result = run_sync(evolve(agent, trainset, config=config))
 
 # Persist the evolved instruction
-provider.save_instruction("my_assistant", result.best_instruction)
+provider.save_instruction("my_assistant", result.evolved_components["instruction"])
 ```
 
 ## Common Pitfalls

--- a/docs/contributing/extending-providers.md
+++ b/docs/contributing/extending-providers.md
@@ -1,0 +1,319 @@
+# Extending Agent Providers
+
+This guide explains how to implement custom agent persistence by creating an `AgentProvider`.
+
+!!! tip "When to Use"
+    Create a custom `AgentProvider` when you need to load and persist agents from a
+    custom storage backend — for example, a database, file system, or remote registry.
+    The evolution engine uses the provider to load agents and save evolved instructions.
+
+## Protocol Definition
+
+The `AgentProvider` protocol defines three methods:
+
+```python
+from gepa_adk import AgentProvider
+
+class AgentProvider(Protocol):
+    def get_agent(self, name: str) -> LlmAgent:
+        """Load an agent by its unique name."""
+        ...
+
+    def save_instruction(self, name: str, instruction: str) -> None:
+        """Persist an evolved instruction for a named agent."""
+        ...
+
+    def list_agents(self) -> list[str]:
+        """List all available agent names."""
+        ...
+```
+
+!!! note "Error Contracts"
+    - `get_agent()` raises `KeyError` for unknown names, `ValueError` for empty/invalid names.
+    - `save_instruction()` raises `KeyError` for unknown names, `ValueError` for empty/invalid names, `IOError` for persistence failures.
+    - `list_agents()` returns an empty list when no agents are available.
+
+## Step-by-Step Implementation
+
+Here is a `JsonFileAgentProvider` that reads and writes agent configurations from JSON files:
+
+```python
+import json
+from pathlib import Path
+
+from google.adk.agents import LlmAgent
+
+from gepa_adk import AgentProvider  # verify structural subtyping
+
+
+class JsonFileAgentProvider:
+    """Agent provider backed by JSON files on disk."""
+
+    def __init__(self, directory: Path) -> None:
+        self._directory = directory
+        self._directory.mkdir(parents=True, exist_ok=True)
+
+    def _agent_path(self, name: str) -> Path:
+        return self._directory / f"{name}.json"
+
+    def get_agent(self, name: str) -> LlmAgent:
+        if not name:
+            raise ValueError("Agent name cannot be empty")
+        path = self._agent_path(name)
+        if not path.exists():
+            raise KeyError(f"Agent not found: {name}")
+        try:
+            data = json.loads(path.read_text())
+        except OSError as e:
+            raise IOError(f"Failed to read agent file: {path}") from e
+        return LlmAgent(
+            name=data["name"],
+            model=data["model"],
+            instruction=data.get("instruction", ""),
+        )
+
+    def save_instruction(self, name: str, instruction: str) -> None:
+        if not name:
+            raise ValueError("Agent name cannot be empty")
+        path = self._agent_path(name)
+        if not path.exists():
+            raise KeyError(f"Agent not found: {name}")
+        try:
+            data = json.loads(path.read_text())
+            data["instruction"] = instruction
+            path.write_text(json.dumps(data, indent=2))
+        except OSError as e:
+            raise IOError(f"Failed to save instruction: {path}") from e
+
+    def list_agents(self) -> list[str]:
+        return [p.stem for p in self._directory.glob("*.json")]
+```
+
+Note that `JsonFileAgentProvider` is a **plain class** — it does not inherit from `AgentProvider`.
+gepa-adk uses structural subtyping (ADR-002): any class with matching method signatures
+satisfies the protocol automatically.
+
+## Registration / Injection
+
+Unlike `ComponentHandler` (which uses a registry), `AgentProvider` is injected directly
+into the evolution engine or your orchestration code:
+
+```python
+from pathlib import Path
+
+provider = JsonFileAgentProvider(Path("./agents"))
+agent = provider.get_agent("my_assistant")
+```
+
+There is no global registry for agent providers — you pass the provider to wherever
+it is needed.
+
+## Runnable Example
+
+This example demonstrates the full get_agent/save_instruction/list_agents cycle
+without requiring an LLM API key:
+
+```python
+import json
+import tempfile
+from pathlib import Path
+
+from google.adk.agents import LlmAgent
+
+from gepa_adk import AgentProvider
+
+
+class JsonFileAgentProvider:
+    def __init__(self, directory: Path) -> None:
+        self._directory = directory
+        self._directory.mkdir(parents=True, exist_ok=True)
+
+    def _agent_path(self, name: str) -> Path:
+        return self._directory / f"{name}.json"
+
+    def get_agent(self, name: str) -> LlmAgent:
+        if not name:
+            raise ValueError("Agent name cannot be empty")
+        path = self._agent_path(name)
+        if not path.exists():
+            raise KeyError(f"Agent not found: {name}")
+        data = json.loads(path.read_text())
+        return LlmAgent(
+            name=data["name"],
+            model=data["model"],
+            instruction=data.get("instruction", ""),
+        )
+
+    def save_instruction(self, name: str, instruction: str) -> None:
+        if not name:
+            raise ValueError("Agent name cannot be empty")
+        path = self._agent_path(name)
+        if not path.exists():
+            raise KeyError(f"Agent not found: {name}")
+        data = json.loads(path.read_text())
+        data["instruction"] = instruction
+        path.write_text(json.dumps(data, indent=2))
+
+    def list_agents(self) -> list[str]:
+        return [p.stem for p in self._directory.glob("*.json")]
+
+
+# Verify protocol compliance
+provider = JsonFileAgentProvider(Path(tempfile.mkdtemp()))
+assert isinstance(provider, AgentProvider)
+
+# Seed an agent config file
+agent_data = {"name": "helper", "model": "gemini-2.5-flash", "instruction": "Be helpful"}
+(provider._directory / "helper.json").write_text(json.dumps(agent_data))
+
+# Demonstrate the full cycle
+print(f"Available agents: {provider.list_agents()}")  # ["helper"]
+
+agent = provider.get_agent("helper")
+print(f"Instruction: {agent.instruction}")  # "Be helpful"
+
+provider.save_instruction("helper", "Be concise and helpful")
+updated = provider.get_agent("helper")
+print(f"Updated: {updated.instruction}")  # "Be concise and helpful"
+```
+
+To integrate with `evolve()`, pass the provider to your orchestration code:
+
+```python
+from gepa_adk import EvolutionConfig, evolve, run_sync
+
+provider = JsonFileAgentProvider(Path("./agents"))
+agent = provider.get_agent("my_assistant")
+
+config = EvolutionConfig(max_iterations=5)
+result = run_sync(evolve(agent, trainset, config=config))
+
+# Persist the evolved instruction
+provider.save_instruction("my_assistant", result.best_instruction)
+```
+
+## Common Pitfalls
+
+!!! warning "Avoid These Mistakes"
+    **Missing validation on empty names.** Both `get_agent()` and `save_instruction()`
+    must raise `ValueError` for empty or `None` names. This is part of the protocol
+    contract — callers expect consistent error behavior.
+
+    **Not persisting before returning.** `save_instruction()` must fully persist the
+    instruction before returning. If a subsequent `get_agent()` call does not reflect
+    the saved instruction, the evolution engine may use stale data.
+
+    **Ignoring IOError handling.** File and network operations can fail. Wrap I/O in
+    try/except and raise `IOError` with a descriptive message so callers can distinguish
+    persistence failures from missing-agent errors.
+
+    **Inheriting from the Protocol.** Do NOT write `class MyProvider(AgentProvider):`.
+    gepa-adk uses structural subtyping (ADR-002) — just implement the methods with
+    matching signatures. Inheriting from a Protocol is misleading and unnecessary.
+
+## Contract Test Skeleton
+
+When adding a new provider, write contract tests to verify protocol compliance. This skeleton
+follows the three-class template established in the project.
+
+!!! note "Exemplar Reference"
+    This skeleton follows the pattern in `tests/contracts/test_agent_provider_protocol.py`
+    — always check the latest exemplar before starting.
+
+```python
+import pytest
+from google.adk.agents import LlmAgent
+
+from gepa_adk import AgentProvider
+
+pytestmark = pytest.mark.contract
+
+
+class TestMyProviderRuntimeCheckable:
+    """Positive compliance: isinstance checks."""
+
+    def test_satisfies_agent_provider_protocol(self):
+        provider = MyProvider()
+        assert isinstance(provider, AgentProvider)
+
+    def test_protocol_has_required_methods(self):
+        provider = MyProvider()
+        assert hasattr(provider, "get_agent")
+        assert hasattr(provider, "save_instruction")
+        assert hasattr(provider, "list_agents")
+
+
+class TestMyProviderBehavior:
+    """Behavioral expectations: return types, error contracts."""
+
+    def test_get_agent_returns_llm_agent(self):
+        provider = MyProvider()
+        # ... register a test agent ...
+        agent = provider.get_agent("test_agent")
+        assert isinstance(agent, LlmAgent)
+
+    def test_get_agent_raises_key_error_for_unknown(self):
+        provider = MyProvider()
+        with pytest.raises(KeyError):
+            provider.get_agent("nonexistent")
+
+    def test_get_agent_raises_value_error_for_empty(self):
+        provider = MyProvider()
+        with pytest.raises(ValueError):
+            provider.get_agent("")
+
+    def test_save_instruction_persists(self):
+        provider = MyProvider()
+        # ... register a test agent ...
+        provider.save_instruction("test_agent", "New instruction")
+        agent = provider.get_agent("test_agent")
+        assert agent.instruction == "New instruction"
+
+    def test_list_agents_returns_list_of_strings(self):
+        provider = MyProvider()
+        result = provider.list_agents()
+        assert isinstance(result, list)
+        assert all(isinstance(n, str) for n in result)
+
+    def test_list_agents_empty_when_no_agents(self):
+        provider = MyProvider()
+        assert provider.list_agents() == []
+
+
+class TestMyProviderNonCompliance:
+    """Negative cases: missing methods fail isinstance."""
+
+    def test_missing_save_instruction_fails(self):
+        class Incomplete:
+            def get_agent(self, name):
+                raise NotImplementedError
+
+            def list_agents(self):
+                return []
+
+        assert not isinstance(Incomplete(), AgentProvider)
+
+    def test_missing_list_agents_fails(self):
+        class Incomplete:
+            def get_agent(self, name):
+                raise NotImplementedError
+
+            def save_instruction(self, name, instruction):
+                pass
+
+        assert not isinstance(Incomplete(), AgentProvider)
+
+    def test_missing_get_agent_fails(self):
+        class Incomplete:
+            def save_instruction(self, name, instruction):
+                pass
+
+            def list_agents(self):
+                return []
+
+        assert not isinstance(Incomplete(), AgentProvider)
+```
+
+## API Reference
+
+- [`AgentProvider`][gepa_adk.ports.agent_provider.AgentProvider] — Protocol definition

--- a/docs/contributing/extending-providers.md
+++ b/docs/contributing/extending-providers.md
@@ -158,12 +158,13 @@ class JsonFileAgentProvider:
 
 
 # Verify protocol compliance
-provider = JsonFileAgentProvider(Path(tempfile.mkdtemp()))
+temp_dir = Path(tempfile.mkdtemp())
+provider = JsonFileAgentProvider(temp_dir)
 assert isinstance(provider, AgentProvider)
 
 # Seed an agent config file
 agent_data = {"name": "helper", "model": "gemini-2.5-flash", "instruction": "Be helpful"}
-(provider._directory / "helper.json").write_text(json.dumps(agent_data))
+(temp_dir / "helper.json").write_text(json.dumps(agent_data))
 
 # Demonstrate the full cycle
 print(f"Available agents: {provider.list_agents()}")  # ["helper"]
@@ -216,8 +217,10 @@ When adding a new provider, write contract tests to verify protocol compliance. 
 follows the three-class template established in the project.
 
 !!! note "Exemplar Reference"
-    This skeleton follows the pattern in `tests/contracts/test_agent_provider_protocol.py`
-    — always check the latest exemplar before starting.
+    This skeleton mirrors the three-class pattern used in
+    `tests/contracts/test_stopper_protocol.py` and
+    `tests/contracts/test_candidate_selector_protocol.py` — always check the latest
+    exemplars before starting.
 
 ```python
 import pytest

--- a/docs/contributing/extending-surfaces.md
+++ b/docs/contributing/extending-surfaces.md
@@ -36,7 +36,7 @@ class ComponentHandler(Protocol):
 ```
 
 !!! note "Contract"
-    - `serialize()` must never raise exceptions — return empty string for missing values.
+    - `serialize()` must never raise exceptions — return an empty string or a sensible default for missing values.
     - `apply()` must never raise exceptions — log a warning and keep the original on failure.
     - `restore()` must always succeed — None values reset to the component default.
     - All methods are synchronous — no I/O operations.
@@ -119,6 +119,8 @@ This example demonstrates the full serialize/apply/restore cycle without requiri
 from google.adk.agents import LlmAgent
 from google.genai.types import GenerateContentConfig
 
+from typing import Any
+
 from gepa_adk import ComponentHandler
 from gepa_adk.adapters import register_handler
 
@@ -130,7 +132,7 @@ class TemperatureHandler:
             return str(config.temperature)
         return "1.0"
 
-    def apply(self, agent, value: str):
+    def apply(self, agent, value: str) -> Any:
         config = getattr(agent, "generate_content_config", None)
         original = config.temperature if config else 1.0
         try:
@@ -188,8 +190,8 @@ result = run_sync(evolve(agent, trainset, config=config, components=["temperatur
 
 !!! warning "Avoid These Mistakes"
     **Raising exceptions instead of returning defaults.** The `serialize()` and `apply()`
-    methods must never raise. On failure, `serialize()` should return an empty string and
-    `apply()` should log a warning and keep the original value.
+    methods must never raise. On failure, `serialize()` should return an empty string or a
+    sensible default, and `apply()` should log a warning and keep the original value.
 
     **Forgetting to restore.** Always implement `restore()`. The evolution engine calls it
     after every evaluation to reset the agent to its original state. A missing or broken
@@ -208,8 +210,10 @@ When adding a new handler, write contract tests to verify protocol compliance. T
 follows the three-class template established in the project.
 
 !!! note "Exemplar Reference"
-    This skeleton follows the pattern in `tests/contracts/test_component_handler_protocol.py`
-    — always check the latest exemplar before starting.
+    This skeleton follows the three-class template used in
+    `tests/contracts/test_stopper_protocol.py` and
+    `tests/contracts/test_candidate_selector_protocol.py` — always check the
+    latest exemplar before starting.
 
 ```python
 import pytest
@@ -244,7 +248,7 @@ class TestMyHandlerBehavior:
     def test_apply_returns_original(self):
         handler = MyHandler()
         original = handler.apply(agent, "new_value")
-        # original should be the previous value
+        assert original is not None  # must return previous value
 
     def test_apply_restore_idempotent(self):
         handler = MyHandler()

--- a/docs/contributing/extending-surfaces.md
+++ b/docs/contributing/extending-surfaces.md
@@ -20,8 +20,7 @@ This guide explains how to add new evolvable surfaces to gepa-adk by implementin
 The `ComponentHandler` protocol defines three methods for the serialize/apply/restore cycle:
 
 ```python
-from gepa_adk import ComponentHandler
-
+# Protocol definition (from gepa_adk.ports.component_handler — shown for reference)
 class ComponentHandler(Protocol):
     def serialize(self, agent: LlmAgent) -> str:
         """Extract current component value as a string."""
@@ -47,6 +46,8 @@ class ComponentHandler(Protocol):
 Here is a `TemperatureHandler` that evolves the `generate_content_config.temperature` parameter:
 
 ```python
+from typing import Any
+
 from gepa_adk import ComponentHandler  # verify structural subtyping
 
 
@@ -59,7 +60,7 @@ class TemperatureHandler:
             return str(config.temperature)
         return "1.0"
 
-    def apply(self, agent, value: str):
+    def apply(self, agent, value: str) -> Any:
         config = getattr(agent, "generate_content_config", None)
         original = config.temperature if config else 1.0
         try:
@@ -174,15 +175,13 @@ register_handler("temperature", handler)
 To integrate with `evolve()`, include the component name in your candidate:
 
 ```python
-from gepa_adk import Candidate, EvolutionConfig, evolve, run_sync
+from gepa_adk import EvolutionConfig, evolve, run_sync
 
 # Register handler before evolution
 register_handler("temperature", TemperatureHandler())
 
 config = EvolutionConfig(max_iterations=5)
-candidate = Candidate(components={"temperature": "0.7"})
-
-result = run_sync(evolve(agent, trainset, config=config, seed=candidate))
+result = run_sync(evolve(agent, trainset, config=config, components=["temperature"]))
 ```
 
 ## Common Pitfalls

--- a/docs/contributing/extending-surfaces.md
+++ b/docs/contributing/extending-surfaces.md
@@ -1,0 +1,292 @@
+# Extending Evolvable Surfaces
+
+This guide explains how to add new evolvable surfaces to gepa-adk by implementing the `ComponentHandler` protocol.
+
+!!! tip "When to Use"
+    Create a custom `ComponentHandler` when you need to evolve an agent attribute
+    beyond the built-in surfaces (instruction, output_schema, generate_content_config).
+    For example, evolving temperature, tool configurations, or custom metadata.
+
+## Available Built-in Handlers
+
+| Handler | Component | Purpose |
+|---------|-----------|---------|
+| `InstructionHandler` | `instruction` | Agent system prompt |
+| `OutputSchemaHandler` | `output_schema` | Pydantic output schema |
+| `GenerateContentConfigHandler` | `generate_content_config` | LLM generation parameters |
+
+## Protocol Definition
+
+The `ComponentHandler` protocol defines three methods for the serialize/apply/restore cycle:
+
+```python
+from gepa_adk import ComponentHandler
+
+class ComponentHandler(Protocol):
+    def serialize(self, agent: LlmAgent) -> str:
+        """Extract current component value as a string."""
+        ...
+
+    def apply(self, agent: LlmAgent, value: str) -> Any:
+        """Apply a new value to the agent, return the original for restoration."""
+        ...
+
+    def restore(self, agent: LlmAgent, original: Any) -> None:
+        """Reinstate the original value after evaluation."""
+        ...
+```
+
+!!! note "Contract"
+    - `serialize()` must never raise exceptions — return empty string for missing values.
+    - `apply()` must never raise exceptions — log a warning and keep the original on failure.
+    - `restore()` must always succeed — None values reset to the component default.
+    - All methods are synchronous — no I/O operations.
+
+## Step-by-Step Implementation
+
+Here is a `TemperatureHandler` that evolves the `generate_content_config.temperature` parameter:
+
+```python
+from gepa_adk import ComponentHandler  # verify structural subtyping
+
+
+class TemperatureHandler:
+    """Handler for evolving the temperature parameter."""
+
+    def serialize(self, agent) -> str:
+        config = getattr(agent, "generate_content_config", None)
+        if config and config.temperature is not None:
+            return str(config.temperature)
+        return "1.0"
+
+    def apply(self, agent, value: str):
+        config = getattr(agent, "generate_content_config", None)
+        original = config.temperature if config else 1.0
+        try:
+            new_temp = float(value)
+            if config:
+                config.temperature = new_temp
+        except (ValueError, TypeError):
+            pass  # keep original on invalid input
+        return original
+
+    def restore(self, agent, original) -> None:
+        config = getattr(agent, "generate_content_config", None)
+        if config:
+            config.temperature = original
+```
+
+Note that `TemperatureHandler` is a **plain class** — it does not inherit from `ComponentHandler`.
+gepa-adk uses structural subtyping (ADR-002): any class with matching method signatures
+satisfies the protocol automatically.
+
+## Registration
+
+Register your handler with the `ComponentHandlerRegistry` so the evolution engine discovers it:
+
+```python
+from gepa_adk.adapters import register_handler
+
+register_handler("temperature", TemperatureHandler())
+```
+
+The engine uses `get_handler()` to look up handlers by component name:
+
+```python
+from gepa_adk.adapters import get_handler
+
+handler = get_handler("temperature")
+original = handler.apply(agent, "0.5")
+# ... evaluate agent ...
+handler.restore(agent, original)
+```
+
+You can also create a dedicated registry if you need isolation from the global default:
+
+```python
+from gepa_adk.adapters import ComponentHandlerRegistry
+
+my_registry = ComponentHandlerRegistry()
+my_registry.register("temperature", TemperatureHandler())
+```
+
+## Runnable Example
+
+This example demonstrates the full serialize/apply/restore cycle without requiring an LLM API key:
+
+```python
+from google.adk.agents import LlmAgent
+from google.genai.types import GenerateContentConfig
+
+from gepa_adk import ComponentHandler
+from gepa_adk.adapters import register_handler
+
+
+class TemperatureHandler:
+    def serialize(self, agent) -> str:
+        config = getattr(agent, "generate_content_config", None)
+        if config and config.temperature is not None:
+            return str(config.temperature)
+        return "1.0"
+
+    def apply(self, agent, value: str):
+        config = getattr(agent, "generate_content_config", None)
+        original = config.temperature if config else 1.0
+        try:
+            new_temp = float(value)
+            if config:
+                config.temperature = new_temp
+        except (ValueError, TypeError):
+            pass
+        return original
+
+    def restore(self, agent, original) -> None:
+        config = getattr(agent, "generate_content_config", None)
+        if config:
+            config.temperature = original
+
+
+# Verify protocol compliance
+handler = TemperatureHandler()
+assert isinstance(handler, ComponentHandler)
+
+# Create a test agent
+agent = LlmAgent(
+    name="demo",
+    model="gemini-2.5-flash",
+    instruction="Be helpful",
+    generate_content_config=GenerateContentConfig(temperature=0.7),
+)
+
+# Serialize → Apply → Restore cycle
+print(f"Original: {handler.serialize(agent)}")  # "0.7"
+
+original = handler.apply(agent, "0.3")
+print(f"After apply: {handler.serialize(agent)}")  # "0.3"
+
+handler.restore(agent, original)
+print(f"After restore: {handler.serialize(agent)}")  # "0.7"
+
+# Register for use in evolution
+register_handler("temperature", handler)
+```
+
+To integrate with `evolve()`, include the component name in your candidate:
+
+```python
+from gepa_adk import Candidate, EvolutionConfig, evolve, run_sync
+
+# Register handler before evolution
+register_handler("temperature", TemperatureHandler())
+
+config = EvolutionConfig(max_iterations=5)
+candidate = Candidate(components={"temperature": "0.7"})
+
+result = run_sync(evolve(agent, trainset, config=config, seed=candidate))
+```
+
+## Common Pitfalls
+
+!!! warning "Avoid These Mistakes"
+    **Raising exceptions instead of returning defaults.** The `serialize()` and `apply()`
+    methods must never raise. On failure, `serialize()` should return an empty string and
+    `apply()` should log a warning and keep the original value.
+
+    **Forgetting to restore.** Always implement `restore()`. The evolution engine calls it
+    after every evaluation to reset the agent to its original state. A missing or broken
+    `restore()` causes state corruption across iterations.
+
+    **Not handling `None` values.** Agent attributes may be `None` (e.g., no
+    `generate_content_config` set). Guard with `getattr()` and `None` checks.
+
+    **Inheriting from the Protocol.** Do NOT write `class MyHandler(ComponentHandler):`.
+    gepa-adk uses structural subtyping (ADR-002) — just implement the methods with
+    matching signatures. Inheriting from a Protocol is misleading and unnecessary.
+
+## Contract Test Skeleton
+
+When adding a new handler, write contract tests to verify protocol compliance. This skeleton
+follows the three-class template established in the project.
+
+!!! note "Exemplar Reference"
+    This skeleton follows the pattern in `tests/contracts/test_component_handler_protocol.py`
+    — always check the latest exemplar before starting.
+
+```python
+import pytest
+
+from gepa_adk import ComponentHandler
+
+pytestmark = pytest.mark.contract
+
+
+class TestMyHandlerRuntimeCheckable:
+    """Positive compliance: isinstance checks."""
+
+    def test_satisfies_component_handler_protocol(self):
+        handler = MyHandler()
+        assert isinstance(handler, ComponentHandler)
+
+    def test_protocol_has_required_methods(self):
+        handler = MyHandler()
+        assert hasattr(handler, "serialize")
+        assert hasattr(handler, "apply")
+        assert hasattr(handler, "restore")
+
+
+class TestMyHandlerBehavior:
+    """Behavioral expectations: return types, state transitions."""
+
+    def test_serialize_returns_string(self):
+        handler = MyHandler()
+        result = handler.serialize(agent)
+        assert isinstance(result, str)
+
+    def test_apply_returns_original(self):
+        handler = MyHandler()
+        original = handler.apply(agent, "new_value")
+        # original should be the previous value
+
+    def test_apply_restore_idempotent(self):
+        handler = MyHandler()
+        original_value = handler.serialize(agent)
+        returned = handler.apply(agent, "new_value")
+        handler.restore(agent, returned)
+        assert handler.serialize(agent) == original_value
+
+    def test_serialize_returns_empty_for_missing(self):
+        handler = MyHandler()
+        result = handler.serialize(agent_without_component)
+        assert result == ""
+
+
+class TestMyHandlerNonCompliance:
+    """Negative cases: missing methods fail isinstance."""
+
+    def test_missing_apply_fails(self):
+        class Incomplete:
+            def serialize(self, agent):
+                return ""
+
+            def restore(self, agent, original):
+                pass
+
+        assert not isinstance(Incomplete(), ComponentHandler)
+
+    def test_missing_restore_fails(self):
+        class Incomplete:
+            def serialize(self, agent):
+                return ""
+
+            def apply(self, agent, value):
+                return None
+
+        assert not isinstance(Incomplete(), ComponentHandler)
+```
+
+## API Reference
+
+- [`ComponentHandler`][gepa_adk.ports.component_handler.ComponentHandler] — Protocol definition
+- [`ComponentHandlerRegistry`][gepa_adk.adapters.components.component_handlers.ComponentHandlerRegistry] — Handler registry
+- [`get_handler()`][gepa_adk.adapters.components.component_handlers.get_handler] — Default registry lookup
+- [`register_handler()`][gepa_adk.adapters.components.component_handlers.register_handler] — Default registry registration

--- a/docs/contributing/extending.md
+++ b/docs/contributing/extending.md
@@ -1,0 +1,10 @@
+# Extending gepa-adk
+
+gepa-adk uses Protocol-based extension points (ADR-002) so you can add new
+capabilities without modifying the core library. Implement the required methods
+on a plain class — no inheritance needed.
+
+## Available Extension Points
+
+- **[Evolvable Surfaces](extending-surfaces.md)** — Add new agent attributes to the evolution loop via the `ComponentHandler` protocol (e.g., temperature, tool configs).
+- **[Agent Providers](extending-providers.md)** — Implement custom agent loading and persistence backends via the `AgentProvider` protocol (e.g., database, file system).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,5 +186,9 @@ nav:
       - Multi-Agent Addressing: adr/ADR-012-multi-agent-component-addressing.md
   - Changelog: changelog.md
   - Contributing:
+      - Extending:
+        - contributing/extending.md
+        - Evolvable Surfaces: contributing/extending-surfaces.md
+        - Agent Providers: contributing/extending-providers.md
       - Docstring Templates: contributing/docstring-templates.md
       - Releasing: contributing/releasing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,8 +187,8 @@ nav:
   - Changelog: changelog.md
   - Contributing:
       - Extending:
-        - contributing/extending.md
-        - Evolvable Surfaces: contributing/extending-surfaces.md
-        - Agent Providers: contributing/extending-providers.md
+          - contributing/extending.md
+          - Evolvable Surfaces: contributing/extending-surfaces.md
+          - Agent Providers: contributing/extending-providers.md
       - Docstring Templates: contributing/docstring-templates.md
       - Releasing: contributing/releasing.md

--- a/src/gepa_adk/__init__.py
+++ b/src/gepa_adk/__init__.py
@@ -25,7 +25,9 @@ Attributes:
     VideoValidationError (class): Raised for invalid video input.
     AsyncGEPAEngine (class): Core async evolution engine.
     MergeProposer (class): Proposes merged candidates from the Pareto frontier.
+    AgentProvider (protocol): Protocol for loading and persisting agents.
     AsyncGEPAAdapter (protocol): Async adapter protocol for evaluation.
+    ComponentHandler (protocol): Protocol for component serialization/application.
     EvaluationBatch (class): Evaluation results container for adapters.
     DataInst (type): Type variable for adapter input instances.
     Trajectory (type): Type variable for adapter traces.
@@ -150,7 +152,9 @@ from gepa_adk.domain import (  # noqa: E402
 )
 from gepa_adk.engine import AsyncGEPAEngine, MergeProposer  # noqa: E402
 from gepa_adk.ports import (  # noqa: E402
+    AgentProvider,
     AsyncGEPAAdapter,
+    ComponentHandler,
     DataInst,
     EvaluationBatch,
     RolloutOutput,
@@ -185,7 +189,9 @@ __all__ = [
     "AsyncGEPAEngine",
     "MergeProposer",
     # Ports
+    "AgentProvider",
     "AsyncGEPAAdapter",
+    "ComponentHandler",
     "EvaluationBatch",
     "DataInst",
     "Trajectory",

--- a/src/gepa_adk/adapters/media/video_blob_service.py
+++ b/src/gepa_adk/adapters/media/video_blob_service.py
@@ -250,7 +250,11 @@ class VideoBlobService:
         loop = asyncio.get_running_loop()
 
         def read_file() -> bytes:
-            """Read video file bytes from disk."""
+            """Read video file bytes from disk.
+
+            Returns:
+                Raw bytes of the video file.
+            """
             with open(video_path, "rb") as f:
                 return f.read()
 

--- a/src/gepa_adk/domain/state.py
+++ b/src/gepa_adk/domain/state.py
@@ -158,6 +158,10 @@ class ParetoFrontier:
     def get_non_dominated(self) -> set[int]:
         """Return candidate indices that lead any example.
 
+        Returns:
+            Set of candidate indices that are non-dominated (lead at
+            least one example).
+
         Note:
             Outputs the union of all leader sets across example indices.
         """
@@ -168,6 +172,10 @@ class ParetoFrontier:
 
     def get_selection_weights(self) -> dict[int, int]:
         """Return selection weights based on leadership frequency.
+
+        Returns:
+            Mapping of candidate index to leadership count, usable as
+            weights for weighted sampling.
 
         Note:
             Outputs weights proportional to how many examples each candidate
@@ -438,6 +446,9 @@ class ParetoState:
         indices: Sequence[int | None], label: str
     ) -> list[int | None]:
         """Validate parent indices for genealogy tracking.
+
+        Returns:
+            Validated list of parent indices (int or None).
 
         Raises:
             TypeError: If any element in indices is not int or None.


### PR DESCRIPTION
Contributors had no documentation for extending gepa-adk with custom evolvable surfaces or agent providers, forcing them to read internal source code. This adds dedicated guide pages for both extension points using the project's Protocol-based extension model.

- Add `docs/contributing/extending-surfaces.md` with ComponentHandler guide: protocol definition, TemperatureHandler recipe, registration, runnable example, pitfalls, contract test skeleton
- Add `docs/contributing/extending-providers.md` with AgentProvider guide: protocol definition, JsonFileAgentProvider recipe, injection pattern, runnable example, pitfalls, contract test skeleton
- Add `docs/contributing/extending.md` index page linking both guides
- Update `mkdocs.yml` nav with Contributing > Extending subsection
- Add `AgentProvider` and `ComponentHandler` to `gepa_adk.__init__.__all__` for top-level imports
- Fix broken API references in evolve() integration snippets (nonexistent `result.best_instruction` and `seed=` parameter)

Test: `uv run mkdocs build --strict` (2 pre-existing warnings only), `uv run pytest`

fix(docs): correct broken API references in extension point guides

- Fix result.best_instruction to result.evolved_components["instruction"]
- Replace seed=candidate with components=["temperature"] (actual API)
- Replace import lines in protocol reference blocks with comments
- Add missing -> Any return annotation and typing import

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Verify all code examples in guide pages are syntactically valid and use public imports only (`from gepa_adk import ...`)
- Confirm contract test skeletons follow three-class template from Story 3.2
- Check MkDocs nav renders correctly under Contributing > Extending

### Related
- Story 3.1: Critic preset factory (established public API export pattern)
- Story 3.2: Contract test gaps (established three-class template used in skeletons)
- ADR-002: Protocol Interfaces (structural subtyping rationale)