### PR TITLE
feat(stoppers): add RegressionStopper with score decline detection

### DIFF
--- a/_bmad-output/implementation-artifacts/6-1-regression-detection-stopper.md
+++ b/_bmad-output/implementation-artifacts/6-1-regression-detection-stopper.md
@@ -1,0 +1,318 @@
+# Story 6.1: Regression Detection Stopper
+
+Branch: feat/stoppers-6-1-regression-detection-stopper
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a developer,
+I want evolution to stop automatically if scores consistently decline,
+so that I don't waste compute on evolution runs that are degrading.
+
+## Acceptance Criteria
+
+1. `adapters/stoppers/regression.py` exists and contains `RegressionStopper` implementing `StopperProtocol` via structural subtyping (no inheritance)
+2. The stopper detects score decline: when `best_score` at iteration N is lower than `best_score` at iteration N-K (configurable lookback `window`, default `window=3`)
+3. When regression is detected, `__call__` returns `True`, which causes the engine to set `stop_reason = StopReason.STOPPER_TRIGGERED` (engine handles this automatically — stopper just returns `True`)
+4. `RegressionStopper` can be composed with existing stoppers via `CompositeStopper`
+5. `RegressionStopper` is added to `tests/contracts/test_stopper_protocol.py` `TestStopperProtocolRuntimeCheckable` class (convention: one contract file per Protocol, not per implementation)
+6. Unit tests at `tests/unit/adapters/stoppers/test_regression.py` cover: regression with default window, custom window, no regression with improving scores, edge case with insufficient history
+7. `RegressionStopper` is exported from `gepa_adk.adapters.stoppers` and from `gepa_adk` top-level
+
+## Tasks / Subtasks
+
+- [x] Task 1: Implement `RegressionStopper` (AC: 1, 2, 3, 4)
+  - [x] 1.1 Create `src/gepa_adk/adapters/stoppers/regression.py`
+  - [x] 1.2 Implement as a **plain class** (NOT dataclass — all other stoppers use plain classes):
+    ```python
+    class RegressionStopper:
+        def __init__(self, *, window: int = 3) -> None:
+            if window < 1:
+                raise ConfigurationError(...)
+            self.window = window
+            self._score_history: list[float] = []
+    ```
+  - [x] 1.3 Validate `window >= 1` in `__init__` — raise `ConfigurationError` with `field="window"`, `value=window`, `constraint="Must be >= 1"`
+  - [x] 1.4 Implement `__call__(self, state: StopperState) -> bool`:
+    - Append `state.best_score` to `_score_history`
+    - If `len(_score_history) <= window`, return `False` (insufficient history)
+    - Return `_score_history[-1] < _score_history[-(window + 1)]`
+  - [x] 1.5 Implement `setup(self) -> None` that clears `self._score_history = []` — engine calls this at the start of each run, making the stopper safe to reuse across multiple evolution runs
+  - [x] 1.6 Add module-level docstring and `__all__ = ["RegressionStopper"]` at file BOTTOM
+  - [x] 1.7 Add structlog event on detection: `logger.info("stopper.regression.triggered", window=self.window, current_score=..., baseline_score=...)`
+
+- [x] Task 2: Wire exports (AC: 7)
+  - [x] 2.1 Add `from gepa_adk.adapters.stoppers.regression import RegressionStopper` to `adapters/stoppers/__init__.py` and include in its `__all__`
+  - [x] 2.2 Add `RegressionStopper` to `adapters/__init__.py` re-exports and `__all__`
+  - [x] 2.3 Add `RegressionStopper` to `gepa_adk/__init__.py` imports and `__all__`
+  - [x] 2.4 Update `docs/guides/stoppers.md` — add `RegressionStopper` to the Available Stoppers table: `| \`RegressionStopper(window)\` | Stop when score declines over N iterations | Detecting degrading runs |`
+
+- [x] Task 3: Contract test (AC: 5)
+  - [x] 3.1 Add `RegressionStopper` to `tests/contracts/test_stopper_protocol.py` → `TestStopperProtocolRuntimeCheckable` class: add `test_regression_stopper_satisfies_protocol` asserting `isinstance(RegressionStopper(), StopperProtocol)`
+  - [x] 3.2 Do NOT create a new `test_regression_stopper_contract.py` — convention is one contract file per Protocol (Story 3.2 standard). Behavioral tests for `RegressionStopper` belong in unit tests (Task 4)
+
+- [x] Task 4: Unit tests (AC: 6)
+  - [x] 4.1 Create `tests/unit/adapters/stoppers/test_regression.py`
+  - [x] 4.2 Set `pytestmark = pytest.mark.unit` at module level
+  - [x] 4.3 Create `make_state(best_score, iteration=0)` helper fixture or factory
+  - [x] 4.4 `TestRegressionStopperInitialization` — valid init, `window=1`, `window=3` (default), `window=0` raises `ConfigurationError`, `window=-1` raises `ConfigurationError`
+  - [x] 4.5 `TestRegressionStopperBehavior` — core scenarios:
+    - Insufficient history returns False (< window+1 calls)
+    - Exactly at window+1 calls: regression detected returns True
+    - Exactly at window+1 calls: no regression returns False
+    - Improving scores: never returns True
+    - Custom window (window=5): needs 6 calls before detection
+  - [x] 4.6 `TestRegressionStopperEdgeCases` — boundary and corner cases:
+    - `window=1`: detects single-step regression immediately (after 2 calls)
+    - Scores flat (plateau): `0.8, 0.8, 0.8, 0.8` — equal is NOT a regression (not `<`)
+    - Same stopper instance called N >> window times: history grows but detection still uses last vs. N-K, does not reset
+    - Scores recover then decline: `[0.5, 0.6, 0.7, 0.4]` with window=3 — 0.4 < 0.5 → True
+  - [x] 4.7 `TestRegressionStopperComposition` — compose with `CompositeStopper`:
+    - `CompositeStopper([RegressionStopper(window=3), ScoreThresholdStopper(0.99)], mode="any")` — returns `isinstance(..., StopperProtocol)` and works correctly
+  - [x] 4.8 `TestRegressionStopperProtocolCompliance` — `isinstance(RegressionStopper(), StopperProtocol)` is True; `__call__` returns `bool`
+- [x] Task 5: Final verification (AC: 1–7)
+  - [x] 5.1 Run `uv run pytest tests/contracts/ -x` — all green, count >= 453 (454 passed)
+  - [x] 5.2 Run `uv run pytest tests/unit/adapters/stoppers/ -x` — all green
+  - [x] 5.3 Run `uv run pytest` — zero regressions from full suite (2147 passed, 1 skipped)
+  - [x] 5.4 Verify `from gepa_adk import RegressionStopper` works in a Python REPL
+  - [x] 5.5 Run `uv run ty check src` — exits 0
+  - [x] 5.6 Run `python scripts/check_protocol_coverage.py` — still 12/12 (RegressionStopper is an implementation, not a new Protocol — no new contract test file mapping needed for the coverage script)
+
+- [x] Task 6: Instance reuse safety test (AC: implied by setup() lifecycle)
+  - [x] 6.1 In `TestRegressionStopperEdgeCases`, add `test_setup_clears_history`: call stopper 4 times (trigger regression), call `stopper.setup()`, then call again — verify history is cleared and stopper no longer fires immediately
+  - [x] 6.2 Verify engine calls `setup()` at start of each run (read `async_engine.py` `_setup_stoppers()` — already calls `setup()` if present via `getattr`)
+
+- [ ] [TEA] Testing maturity: add a test verifying that `CompositeStopper` correctly propagates `setup()` calls to all child stoppers including `RegressionStopper` (engine only calls `setup()` on top-level stoppers, not nested ones — verify this is handled or document the limitation). (cross-cutting, optional)
+
+## Dev Notes
+
+### Critical Architecture Insight: StopperState Has No Score History
+
+`StopperState` (in `src/gepa_adk/domain/stopper.py`) contains:
+```python
+@dataclass(frozen=True, slots=True)
+class StopperState:
+    iteration: int
+    best_score: float          # ← only the current best
+    stagnation_counter: int
+    total_evaluations: int
+    candidates_count: int
+    elapsed_seconds: float
+```
+
+There is NO score history in `StopperState`. `RegressionStopper` MUST track `best_score` across calls internally. This is the same stateful pattern as `SignalStopper` (which tracks `_stop_requested` across calls).
+
+### Implementation Pattern
+
+**Use a plain class — NOT a dataclass.** All existing stoppers (`ScoreThresholdStopper`, `TimeoutStopper`, `SignalStopper`, etc.) use plain classes with `__init__`. Do not deviate from this pattern.
+
+```python
+class RegressionStopper:
+    """Stops evolution when best score declines over a lookback window.
+
+    Detects regression by comparing the current best score to the best score
+    from ``window`` iterations ago. Returns ``True`` (stop) when the current
+    score is strictly lower than the score ``window`` steps prior.
+
+    Requires at least ``window + 1`` calls before any regression can be detected.
+    Call ``setup()`` (or let the engine call it) to reset history between runs.
+
+    Args:
+        window: Number of iterations to look back for comparison. Must be >= 1.
+            Default is 3.
+    """
+
+    def __init__(self, *, window: int = 3) -> None:
+        if window < 1:
+            raise ConfigurationError(
+                f"RegressionStopper window must be >= 1, got {window}",
+                field="window",
+                value=window,
+                constraint="Must be >= 1",
+            )
+        self.window = window
+        self._score_history: list[float] = []
+
+    def setup(self) -> None:
+        """Reset score history. Called by engine at start of each run."""
+        self._score_history = []
+
+    def __call__(self, state: StopperState) -> bool:
+        self._score_history.append(state.best_score)
+        if len(self._score_history) <= self.window:
+            return False
+        current = self._score_history[-1]
+        baseline = self._score_history[-(self.window + 1)]
+        if current < baseline:
+            logger.info(
+                "stopper.regression.triggered",
+                window=self.window,
+                current_score=current,
+                baseline_score=baseline,
+            )
+            return True
+        return False
+
+
+__all__ = ["RegressionStopper"]
+```
+
+### Regression Logic Verification
+
+Window=3 example with history `[0.5, 0.6, 0.7, 0.4]` (4 calls):
+- After call 1: history=[0.5], len=1 ≤ 3 → False (cold start)
+- After call 2: history=[0.5, 0.6], len=2 ≤ 3 → False
+- After call 3: history=[0.5, 0.6, 0.7], len=3 ≤ 3 → False
+- After call 4: history=[0.5, 0.6, 0.7, 0.4], len=4 > 3 → compare history[-1]=0.4 vs history[-4]=0.5 → 0.4 < 0.5 → **True** ✅
+
+Equal scores (plateau `[0.8, 0.8, 0.8, 0.8]`):
+- After call 4: history[-1]=0.8, history[-4]=0.8 → 0.8 < 0.8 → **False** (equal is NOT regression) ✅
+
+### How Engine Handles stop_reason
+
+The engine automatically sets `StopReason.STOPPER_TRIGGERED` when ANY stopper in `config.stop_callbacks` returns `True`. The `RegressionStopper` just needs to return `True` — no additional code needed to set stop reason. See `src/gepa_adk/engine/async_engine.py` → `_should_stop()`.
+
+### Lifecycle: setup() Required for Instance Reuse Safety
+
+`RegressionStopper` implements `setup()` to clear `_score_history`. The engine calls `setup()` at the start of each run (via `getattr` check in `_setup_stoppers()`). This makes the stopper safe to reuse across multiple `evolve()` calls with the same instance. Without `setup()`, history from run N would bleed into run N+1.
+
+### Exception Pattern (for __init__ validation)
+
+```python
+from gepa_adk.domain.exceptions import ConfigurationError
+
+raise ConfigurationError(
+    f"RegressionStopper window must be >= 1, got {self.window}",
+    field="window",
+    value=self.window,
+    constraint="Must be >= 1",
+)
+```
+
+No `cause=e` or `from e` needed — this is a direct raise, not wrapping another exception.
+
+### Export Chain
+
+```
+adapters/stoppers/regression.py
+  └─ adapters/stoppers/__init__.py  (add RegressionStopper)
+       └─ adapters/__init__.py       (add RegressionStopper)
+            └─ gepa_adk/__init__.py  (add RegressionStopper)
+```
+
+Verify all four `__all__` lists are updated. Check `test_adapter_reexports.py` for the existing reexport test pattern.
+
+### Contract Test Convention (Overrides Epic AC)
+
+The epics AC specified `tests/contracts/test_regression_stopper_contract.py` but this was written before Story 3.2 established the **one-file-per-Protocol** standard. `RegressionStopper` is an *implementation*, not a new Protocol. Convention takes precedence:
+- Add `RegressionStopper` isinstance check to **existing** `test_stopper_protocol.py` → `TestStopperProtocolRuntimeCheckable`
+- All behavioral tests go in unit tests (`tests/unit/adapters/stoppers/test_regression.py`)
+- Do NOT create a new contract file for this implementation
+
+### Structlog Usage
+
+```python
+import structlog
+
+logger = structlog.get_logger(__name__)
+```
+
+Event name: `stopper.regression.triggered` (dot-notation per python.md conventions).
+
+### Documentation Impact
+
+`RegressionStopper` is a new public API symbol exported from `gepa_adk`. Impact:
+- **API docs**: mkdocstrings auto-generates from docstring — no manual docs work needed. Ensure the class docstring is complete (Args, Returns via `__call__` docstring).
+- **Changelog**: `feat(stoppers):` commit type will trigger a changelog entry in v2.2.0 — no extra work.
+- **CONTRIBUTING/guides**: `docs/guides/stoppers.md` has an Available Stoppers table — add `RegressionStopper(window)` | Stop when score declines over N iterations | Detecting degrading runs. **This is required, not optional.**
+- No ADR required (fits existing Decision 6: keep direct instantiation, no factory).
+
+### Previous Story Learnings (from Epic 3)
+
+**Story 3.1 (Critic Preset Factory):**
+- Export chain must update ALL four `__all__` lists — checked via `test_adapter_reexports.py`
+- `ConfigurationError` fields: `field`, `value`, `constraint` (no `suggestion` field)
+- Model handling with conditional kwargs — not relevant here but pattern useful
+
+**Story 3.2 (Contract Test Gaps):**
+- Three-class template: `TestXxxRuntimeCheckable`, `TestXxxBehavior`, `TestXxxNonCompliance`
+- `pytestmark = pytest.mark.contract` at module level
+- Import Protocol from `gepa_adk.ports`, not internal module
+- Document `runtime_checkable` limitation: only checks method existence, not signature
+
+**Story 3.3 (Extension Point Docs):**
+- Public API imports: `from gepa_adk import RegressionStopper` (NOT `from gepa_adk.adapters.stoppers import ...`) in examples
+
+### Project Structure Notes
+
+**New files:**
+- `src/gepa_adk/adapters/stoppers/regression.py` — new stopper implementation
+- `tests/unit/adapters/stoppers/test_regression.py` — unit tests
+
+**Modified files:**
+- `src/gepa_adk/adapters/stoppers/__init__.py` — add `RegressionStopper` export
+- `src/gepa_adk/adapters/__init__.py` — add `RegressionStopper` re-export
+- `src/gepa_adk/__init__.py` — add `RegressionStopper` re-export
+- `tests/contracts/test_stopper_protocol.py` — add `RegressionStopper` to `TestStopperProtocolRuntimeCheckable`
+- `tests/unit/adapters/test_adapter_reexports.py` — add `RegressionStopper` re-export test
+- `docs/guides/stoppers.md` — add `RegressionStopper` to Available Stoppers table
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — status update
+- `_bmad-output/implementation-artifacts/6-1-regression-detection-stopper.md` — task tracking
+
+### References
+
+- [Source: src/gepa_adk/ports/stopper.py — StopperProtocol definition]
+- [Source: src/gepa_adk/domain/stopper.py — StopperState dataclass (no score history)]
+- [Source: src/gepa_adk/adapters/stoppers/signal.py — stateful stopper pattern with internal `_stop_requested`]
+- [Source: src/gepa_adk/adapters/stoppers/threshold.py — plain class stopper pattern, ConfigurationError usage]
+- [Source: src/gepa_adk/adapters/stoppers/composite.py — CompositeStopper for AC4]
+- [Source: src/gepa_adk/adapters/stoppers/__init__.py — export pattern to follow]
+- [Source: src/gepa_adk/engine/async_engine.py — how _should_stop() handles STOPPER_TRIGGERED]
+- [Source: src/gepa_adk/domain/types.py — StopReason enum values]
+- [Source: src/gepa_adk/domain/exceptions.py — ConfigurationError (field, value, constraint only)]
+- [Source: tests/contracts/test_stopper_protocol.py — three-class template exemplar]
+- [Source: tests/unit/adapters/stoppers/test_threshold.py — unit test pattern]
+- [Source: tests/unit/adapters/test_adapter_reexports.py — reexport test pattern]
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 6.1]
+- [Source: _bmad-output/planning-artifacts/architecture.md#Decision 6 — stopper registration]
+- [Source: _bmad-output/project-context.md — arch rules, exception patterns, structlog usage]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 4.6
+
+### Debug Log References
+
+### Completion Notes List
+
+- Implemented `RegressionStopper` as a plain class (matching pattern of all existing stoppers) with `window` parameter (default 3), stateful `_score_history`, and strict less-than comparison for regression detection.
+- Export chain updated across all four `__all__` lists: `regression.py` → `stoppers/__init__.py` → `adapters/__init__.py` → `gepa_adk/__init__.py`.
+- Contract test added to existing `test_stopper_protocol.py` (one-file-per-Protocol convention from Story 3.2).
+- 21 unit tests covering initialization, core behavior, edge cases (plateau, recovery/decline, long history), composition, instance reuse via `setup()`, and protocol compliance.
+- `docs/guides/stoppers.md` Available Stoppers table updated with `RegressionStopper(window)`.
+- `test_adapter_reexports.py` updated with `RegressionStopper` re-export identity test.
+- All tests green: 2147 passed, 454 contract tests, ty check clean, 12/12 protocol coverage.
+- Pre-review party-mode research identified `CompositeStopper` missing `setup()` propagation — fixed with 15-line addition to `composite.py` and a multi-run reuse test. Final suite: 2148 passed.
+
+### File List
+
+- `src/gepa_adk/adapters/stoppers/regression.py` (new)
+- `src/gepa_adk/adapters/stoppers/composite.py` (modified — added setup() propagation to children)
+- `src/gepa_adk/adapters/stoppers/__init__.py` (modified)
+- `src/gepa_adk/adapters/__init__.py` (modified)
+- `src/gepa_adk/__init__.py` (modified)
+- `tests/unit/adapters/stoppers/test_regression.py` (new)
+- `tests/contracts/test_stopper_protocol.py` (modified)
+- `tests/unit/adapters/test_adapter_reexports.py` (modified)
+- `docs/guides/stoppers.md` (modified)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+- `_bmad-output/implementation-artifacts/6-1-regression-detection-stopper.md` (modified)
+
+## Change Log
+
+- 2026-03-11: Code review applied 3 fixes: (1) Added `test_composite_all_short_circuit_skips_regression_history` test documenting that `mode="all"` short-circuit prevents `RegressionStopper` history accumulation when listed second; (2) Added stateful stopper ordering caveat to `CompositeStopper.__call__` docstring; (3) Added dedicated `RegressionStopper` section to `docs/guides/stoppers.md` covering cold-start, plateau, instance reuse, and composition ordering. Fixed misleading "unchanged" comment in `adapters/__init__.py`. Suite: 2149 passed, 1 skipped.
+- 2026-03-11: Implemented `RegressionStopper` — new stopper that detects score regression over a configurable lookback window. Added full export chain, contract test (to existing file), 21 unit tests, docs update, and re-export identity test. All 2147 tests pass, zero regressions.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-03-03
+# generated: 2026-03-08
 # project: gepa-adk
 # project_key: NOKEY
 # tracking_system: file-system
@@ -40,7 +40,7 @@
 #                                                → Epic 6 (Evolution Analytics)
 #                                                → Epic 8 (DX & Docs) [cross-cutting, ongoing]
 
-generated: 2026-03-03
+generated: 2026-03-08
 project: gepa-adk
 project_key: NOKEY
 tracking_system: file-system
@@ -79,15 +79,15 @@ development_status:
   epic-2-retrospective: done
 
   # ── Epic 3: Evolution Control & Extensibility ──
-  epic-3: in-progress
+  epic-3: done
   3-1-implement-critic-preset-factory: done
   3-2-fill-contract-test-gaps: done
-  3-3-extension-point-documentation: review
-  epic-3-retrospective: optional
+  3-3-extension-point-documentation: done
+  epic-3-retrospective: done
 
   # ── Epic 6: Evolution Analytics ──
-  epic-6: backlog
-  6-1-regression-detection-stopper: backlog
+  epic-6: in-progress
+  6-1-regression-detection-stopper: done
   6-2-pareto-frontier-json-export: backlog
   6-3-per-agent-score-attribution: backlog
   epic-6-retrospective: optional

--- a/docs/guides/stoppers.md
+++ b/docs/guides/stoppers.md
@@ -24,6 +24,7 @@ Use stop callbacks when you need:
 | `MaxEvaluationsStopper(n)` | Stop after n total evaluations | API cost control |
 | `TimeoutStopper(seconds)` | Stop after elapsed time | Job time limits |
 | `ScoreThresholdStopper(threshold)` | Stop when score is reached | Early success |
+| `RegressionStopper(window)` | Stop when score declines over N iterations | Detecting degrading runs |
 | `SignalStopper()` | Stop on Ctrl+C or SIGTERM | Graceful shutdown |
 | `FileStopper(path)` | Stop when a file exists | External orchestration |
 | `CompositeStopper([...], mode)` | Combine stoppers | Complex conditions |
@@ -109,6 +110,51 @@ from gepa_adk.adapters.stoppers import ScoreThresholdStopper
 config = EvolutionConfig(
     max_iterations=100,
     stop_callbacks=[ScoreThresholdStopper(0.95)],
+)
+```
+
+### RegressionStopper
+
+Stop when scores are consistently declining over a lookback window:
+
+```python
+from gepa_adk import RegressionStopper
+
+# Stop if score drops compared to where it was 3 iterations ago (default)
+config = EvolutionConfig(
+    max_iterations=100,
+    stop_callbacks=[RegressionStopper()],
+)
+
+# Tighter window — stop if score drops vs just 2 iterations ago
+config = EvolutionConfig(
+    max_iterations=100,
+    stop_callbacks=[RegressionStopper(window=2)],
+)
+```
+
+**Cold-start phase:** `RegressionStopper` requires `window + 1` calls before it can fire. With the default `window=3`, the first 3 iterations are always `False` — this is by design to avoid false positives on noisy early scores.
+
+**Plateau is not regression:** Equal scores (`0.8, 0.8, 0.8, 0.8`) do not trigger a stop. Only a *strictly lower* score than `window` iterations ago triggers regression detection.
+
+**Instance reuse:** Call `stopper.setup()` between runs (or let the engine do it automatically) to reset history. Without this, history from run N bleeds into run N+1.
+
+**Composition ordering caveat:** When using `CompositeStopper(mode="all")`, list `RegressionStopper` **first**. Python's `all()` short-circuits on the first `False` result, so if a non-stateful stopper listed before `RegressionStopper` returns `False`, `RegressionStopper.__call__` is never invoked and its history never accumulates.
+
+```python
+from gepa_adk import RegressionStopper
+from gepa_adk.adapters.stoppers import CompositeStopper, ScoreThresholdStopper
+
+# ✅ Correct: RegressionStopper listed first in mode="all"
+composite = CompositeStopper(
+    [RegressionStopper(window=3), ScoreThresholdStopper(0.95)],
+    mode="all",
+)
+
+# ✅ Safe with mode="any" — short-circuit only fires when stopping anyway
+composite = CompositeStopper(
+    [ScoreThresholdStopper(0.95), RegressionStopper(window=3)],
+    mode="any",
 )
 ```
 
@@ -286,6 +332,7 @@ config = EvolutionConfig(
 - [`FileStopper`][gepa_adk.adapters.stoppers.FileStopper] — File-based stop signal
 - [`TimeoutStopper`][gepa_adk.adapters.stoppers.TimeoutStopper] — Time-based limit
 - [`ScoreThresholdStopper`][gepa_adk.adapters.stoppers.ScoreThresholdStopper] — Score threshold
+- [`RegressionStopper`][gepa_adk.adapters.stoppers.RegressionStopper] — Score regression detection
 - [`SignalStopper`][gepa_adk.adapters.stoppers.SignalStopper] — Signal handling
 - [`CompositeStopper`][gepa_adk.adapters.stoppers.CompositeStopper] — Combine stoppers
 - [`StopperState`][gepa_adk.domain.stopper.StopperState] — State passed to stoppers

--- a/docs/guides/stoppers.md
+++ b/docs/guides/stoppers.md
@@ -115,7 +115,7 @@ config = EvolutionConfig(
 
 ### RegressionStopper
 
-Stop when scores are consistently declining over a lookback window:
+Stop when the score declines compared to `window` iterations ago:
 
 ```python
 from gepa_adk import RegressionStopper

--- a/src/gepa_adk/__init__.py
+++ b/src/gepa_adk/__init__.py
@@ -23,6 +23,7 @@ Attributes:
     EvolutionError (class): Base exception for all gepa-adk errors.
     ConfigurationError (class): Raised when configuration validation fails.
     VideoValidationError (class): Raised for invalid video input.
+    RegressionStopper (class): Stop evolution when score declines over N iterations.
     AsyncGEPAEngine (class): Core async evolution engine.
     MergeProposer (class): Proposes merged candidates from the Pareto frontier.
     AgentProvider (protocol): Protocol for loading and persisting agents.
@@ -124,6 +125,7 @@ from gepa_adk.adapters.selection.component_selector import (  # noqa: E402
     RoundRobinComponentSelector,
     create_component_selector,
 )
+from gepa_adk.adapters.stoppers.regression import RegressionStopper  # noqa: E402
 from gepa_adk.api import (  # noqa: E402
     evolve,
     evolve_group,
@@ -212,6 +214,8 @@ __all__ = [
     "normalize_feedback",
     "create_critic",
     "critic_presets",
+    # Stoppers
+    "RegressionStopper",
     # API
     "evolve",
     "evolve_sync",

--- a/src/gepa_adk/adapters/__init__.py
+++ b/src/gepa_adk/adapters/__init__.py
@@ -14,7 +14,7 @@ Sub-packages:
     components/: Evolvable surface handlers (ComponentHandlerRegistry).
     workflow/: Workflow agent utilities (is_workflow_agent, find_llm_agents).
     media/: Multimodal adapters (VideoBlobService).
-    stoppers/: Evolution stopping conditions (unchanged).
+    stoppers/: Evolution stopping conditions (RegressionStopper, TimeoutStopper).
 
 Attributes:
     ADKAdapter (class): AsyncGEPAAdapter implementation for Google ADK agents.
@@ -110,8 +110,8 @@ from gepa_adk.adapters.selection.evaluation_policy import (
     SubsetEvaluationPolicy,
 )
 
-# Stoppers (unchanged — already a sub-package)
-from gepa_adk.adapters.stoppers import TimeoutStopper
+# Stoppers (updated — RegressionStopper added)
+from gepa_adk.adapters.stoppers import RegressionStopper, TimeoutStopper
 
 # Workflow
 from gepa_adk.adapters.workflow.workflow import (
@@ -162,6 +162,7 @@ __all__ = [
     "FullEvaluationPolicy",
     "SubsetEvaluationPolicy",
     # Stoppers
+    "RegressionStopper",
     "TimeoutStopper",
     # Trial building
     "TrialBuilder",

--- a/src/gepa_adk/adapters/stoppers/__init__.py
+++ b/src/gepa_adk/adapters/stoppers/__init__.py
@@ -8,6 +8,7 @@ Attributes:
     CompositeStopper (class): Combine multiple stoppers with AND/OR logic.
     FileStopper (class): Stop evolution when a specified file exists.
     MaxEvaluationsStopper (class): Stop evolution after maximum evaluations.
+    RegressionStopper (class): Stop evolution when score declines over N iterations.
     ScoreThresholdStopper (class): Stop evolution when best score reaches threshold.
     SignalStopper (class): Stop evolution on Unix signals (SIGINT, SIGTERM).
     TimeoutStopper (class): Stop evolution after a specified timeout.
@@ -68,6 +69,7 @@ Notes:
 from gepa_adk.adapters.stoppers.composite import CompositeStopper
 from gepa_adk.adapters.stoppers.evaluations import MaxEvaluationsStopper
 from gepa_adk.adapters.stoppers.file import FileStopper
+from gepa_adk.adapters.stoppers.regression import RegressionStopper
 from gepa_adk.adapters.stoppers.signal import SignalStopper
 from gepa_adk.adapters.stoppers.threshold import ScoreThresholdStopper
 from gepa_adk.adapters.stoppers.timeout import TimeoutStopper
@@ -76,6 +78,7 @@ __all__ = [
     "CompositeStopper",
     "FileStopper",
     "MaxEvaluationsStopper",
+    "RegressionStopper",
     "ScoreThresholdStopper",
     "SignalStopper",
     "TimeoutStopper",

--- a/src/gepa_adk/adapters/stoppers/composite.py
+++ b/src/gepa_adk/adapters/stoppers/composite.py
@@ -170,6 +170,12 @@ class CompositeStopper:
         Note:
             Only calls setup() on children that implement the method.
             Children without setup() are unaffected.
+
+            If a child stopper's ``setup()`` raises, the exception propagates
+            out of this method. The engine will then exclude the entire
+            ``CompositeStopper`` (all children) from the run, not just the
+            failing child. Write defensive ``setup()`` implementations in
+            custom stoppers to avoid disabling the whole composite.
         """
         for stopper in self.stoppers:
             setup_method = getattr(stopper, "setup", None)

--- a/src/gepa_adk/adapters/stoppers/composite.py
+++ b/src/gepa_adk/adapters/stoppers/composite.py
@@ -109,6 +109,11 @@ class CompositeStopper:
     Notes:
         A composite stopper can contain other composite stoppers for arbitrarily
         complex stopping conditions like "(A OR B) AND (C OR D)".
+
+        Supports ``setup()`` propagation: calling ``setup()`` on a
+        CompositeStopper resets all child stoppers that implement it,
+        making stateful children (e.g., ``RegressionStopper``) safe
+        for reuse across multiple evolution runs.
     """
 
     def __init__(
@@ -155,6 +160,22 @@ class CompositeStopper:
         self.stoppers: list[StopperProtocol] = list(stoppers)
         self.mode: Literal["any", "all"] = mode
 
+    def setup(self) -> None:
+        """Propagate lifecycle resets to all child stoppers that support it.
+
+        Called by the engine at the start of each run. Ensures stateful
+        child stoppers (e.g., RegressionStopper) have their history reset
+        between runs, even when nested inside a CompositeStopper.
+
+        Note:
+            Only calls setup() on children that implement the method.
+            Children without setup() are unaffected.
+        """
+        for stopper in self.stoppers:
+            setup_method = getattr(stopper, "setup", None)
+            if setup_method is not None and callable(setup_method):
+                setup_method()
+
     def __call__(self, state: StopperState) -> bool:
         """Check if evolution should stop based on combined stopper logic.
 
@@ -199,6 +220,14 @@ class CompositeStopper:
             Often called after each iteration. For 'any' mode, evaluation
             short-circuits on first True. For 'all' mode, short-circuits on
             first False.
+
+            **Stateful stopper ordering caveat:** Short-circuit evaluation means
+            stoppers listed later in the sequence may not be called on every
+            iteration. Stateful stoppers (e.g., ``RegressionStopper``) that
+            require being called every iteration to accumulate history must be
+            listed **first** in ``mode='all'`` compositions, or placed before
+            any stopper that frequently returns ``False``. Otherwise the
+            stateful stopper will never accumulate history and can never fire.
         """
         if self.mode == "any":
             return any(stopper(state) for stopper in self.stoppers)

--- a/src/gepa_adk/adapters/stoppers/composite.py
+++ b/src/gepa_adk/adapters/stoppers/composite.py
@@ -167,7 +167,7 @@ class CompositeStopper:
         child stoppers (e.g., RegressionStopper) have their history reset
         between runs, even when nested inside a CompositeStopper.
 
-        Note:
+        Notes:
             Only calls setup() on children that implement the method.
             Children without setup() are unaffected.
 

--- a/src/gepa_adk/adapters/stoppers/regression.py
+++ b/src/gepa_adk/adapters/stoppers/regression.py
@@ -5,7 +5,8 @@ the best score consistently declines over a configurable lookback window,
 preventing wasted compute on degrading runs.
 
 Attributes:
-    RegressionStopper (class): Stop evolution when score declines over N iterations.
+    RegressionStopper (class): Stop evolution when score declines over N iterations,
+        using a bounded ``deque`` for O(1) memory regardless of run length.
 
 Examples:
     Basic usage with default window:
@@ -46,6 +47,8 @@ See Also:
 
 from __future__ import annotations
 
+from collections import deque
+
 import structlog
 
 from gepa_adk.domain.exceptions import ConfigurationError
@@ -80,11 +83,47 @@ class RegressionStopper:
 
         stopper = RegressionStopper(window=3)
 
-        # Simulated evolution calls
-        stopper(StopperState(iteration=0, best_score=0.5, ...))  # False (cold start)
-        stopper(StopperState(iteration=1, best_score=0.6, ...))  # False
-        stopper(StopperState(iteration=2, best_score=0.7, ...))  # False
-        stopper(StopperState(iteration=3, best_score=0.4, ...))  # True (0.4 < 0.5)
+        # Simulated evolution calls (StopperState requires all 6 fields)
+        stopper(
+            StopperState(
+                iteration=0,
+                best_score=0.5,
+                stagnation_counter=0,
+                total_evaluations=0,
+                candidates_count=1,
+                elapsed_seconds=0.0,
+            )
+        )  # False (cold start)
+        stopper(
+            StopperState(
+                iteration=1,
+                best_score=0.6,
+                stagnation_counter=0,
+                total_evaluations=1,
+                candidates_count=1,
+                elapsed_seconds=1.0,
+            )
+        )  # False
+        stopper(
+            StopperState(
+                iteration=2,
+                best_score=0.7,
+                stagnation_counter=0,
+                total_evaluations=2,
+                candidates_count=1,
+                elapsed_seconds=2.0,
+            )
+        )  # False
+        stopper(
+            StopperState(
+                iteration=3,
+                best_score=0.4,
+                stagnation_counter=0,
+                total_evaluations=3,
+                candidates_count=1,
+                elapsed_seconds=3.0,
+            )
+        )  # True (0.4 < 0.5, the baseline from window=3 ago)
         ```
 
     Note:
@@ -107,6 +146,11 @@ class RegressionStopper:
             stopper = RegressionStopper()  # window=3
             stopper = RegressionStopper(window=5)  # window=5
             ```
+
+        Note:
+            Score history is stored in a ``deque(maxlen=window+1)`` so memory
+            usage is bounded to exactly ``window + 1`` floats regardless of
+            run length.
         """
         if window < 1:
             raise ConfigurationError(
@@ -116,14 +160,15 @@ class RegressionStopper:
                 constraint="Must be >= 1",
             )
         self.window = window
-        self._score_history: list[float] = []
+        self._score_history: deque[float] = deque(maxlen=self.window + 1)
 
     def setup(self) -> None:
         """Reset score history. Called by engine at start of each run.
 
-        Clears the internal score history so the stopper can be safely reused
-        across multiple ``evolve()`` calls with the same instance. Without this
-        reset, history from one run would bleed into the next.
+        Clears the internal score history by replacing the bounded deque with
+        a fresh one, so the stopper can be safely reused across multiple
+        ``evolve()`` calls with the same instance. Without this reset, history
+        from one run would bleed into the next.
 
         Examples:
             ```python
@@ -132,7 +177,7 @@ class RegressionStopper:
             stopper.setup()  # reset for next run
             ```
         """
-        self._score_history = []
+        self._score_history = deque(maxlen=self.window + 1)
 
     def __call__(self, state: StopperState) -> bool:
         """Check if evolution should stop due to score regression.
@@ -151,8 +196,27 @@ class RegressionStopper:
         Examples:
             ```python
             stopper = RegressionStopper(window=3)
-            state = StopperState(iteration=3, best_score=0.4, ...)
-            stopper(state)  # True if prior scores were [0.5, 0.6, 0.7]
+            # Prime with 3 cold-start calls
+            for score in [0.5, 0.6, 0.7]:
+                stopper(
+                    StopperState(
+                        iteration=0,
+                        best_score=score,
+                        stagnation_counter=0,
+                        total_evaluations=0,
+                        candidates_count=1,
+                        elapsed_seconds=0.0,
+                    )
+                )
+            state = StopperState(
+                iteration=3,
+                best_score=0.4,
+                stagnation_counter=0,
+                total_evaluations=3,
+                candidates_count=1,
+                elapsed_seconds=3.0,
+            )
+            stopper(state)  # True (0.4 < 0.5, the baseline from window=3 ago)
             ```
         """
         self._score_history.append(state.best_score)

--- a/src/gepa_adk/adapters/stoppers/regression.py
+++ b/src/gepa_adk/adapters/stoppers/regression.py
@@ -1,0 +1,174 @@
+"""Regression detection stopper for evolution termination on score decline.
+
+This module provides a RegressionStopper that terminates evolution when
+the best score consistently declines over a configurable lookback window,
+preventing wasted compute on degrading runs.
+
+Attributes:
+    RegressionStopper (class): Stop evolution when score declines over N iterations.
+
+Examples:
+    Basic usage with default window:
+
+    ```python
+    from gepa_adk import RegressionStopper
+
+    stopper = RegressionStopper()  # window=3
+    # Use stopper in evolution config
+    ```
+
+    Custom lookback window:
+
+    ```python
+    from gepa_adk import RegressionStopper
+
+    stopper = RegressionStopper(window=5)  # Stop if score drops vs 5 iters ago
+    ```
+
+    Composing with other stoppers:
+
+    ```python
+    from gepa_adk import RegressionStopper
+    from gepa_adk.adapters.stoppers import CompositeStopper, ScoreThresholdStopper
+
+    composite = CompositeStopper(
+        [RegressionStopper(window=3), ScoreThresholdStopper(0.99)],
+        mode="any",
+    )
+    ```
+
+See Also:
+    - [`gepa_adk.ports.stopper.StopperProtocol`][gepa_adk.ports.stopper.StopperProtocol]:
+        Protocol interface for stop conditions.
+    - [`gepa_adk.domain.stopper.StopperState`][gepa_adk.domain.stopper.StopperState]:
+        Immutable snapshot of evolution state for stopper decisions.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from gepa_adk.domain.exceptions import ConfigurationError
+from gepa_adk.domain.stopper import StopperState
+
+logger = structlog.get_logger(__name__)
+
+
+class RegressionStopper:
+    """Stops evolution when best score declines over a lookback window.
+
+    Detects regression by comparing the current best score to the best score
+    from ``window`` iterations ago. Returns ``True`` (stop) when the current
+    score is strictly lower than the score ``window`` steps prior.
+
+    Requires at least ``window + 1`` calls before any regression can be detected.
+    Call ``setup()`` (or let the engine call it) to reset history between runs.
+
+    Attributes:
+        window (int): Number of iterations to look back for comparison.
+
+    Args:
+        window: Number of iterations to look back for comparison. Must be >= 1.
+            Default is 3.
+
+    Examples:
+        Detecting degrading runs:
+
+        ```python
+        from gepa_adk import RegressionStopper
+        from gepa_adk.domain.stopper import StopperState
+
+        stopper = RegressionStopper(window=3)
+
+        # Simulated evolution calls
+        stopper(StopperState(iteration=0, best_score=0.5, ...))  # False (cold start)
+        stopper(StopperState(iteration=1, best_score=0.6, ...))  # False
+        stopper(StopperState(iteration=2, best_score=0.7, ...))  # False
+        stopper(StopperState(iteration=3, best_score=0.4, ...))  # True (0.4 < 0.5)
+        ```
+
+    Note:
+        Equal scores (plateau) are NOT considered regression. Only strictly
+        lower scores trigger a stop.
+    """
+
+    def __init__(self, *, window: int = 3) -> None:
+        """Initialize RegressionStopper with lookback window.
+
+        Args:
+            window: Number of iterations to look back for score comparison.
+                Must be >= 1. Default is 3.
+
+        Raises:
+            ConfigurationError: If window < 1.
+
+        Examples:
+            ```python
+            stopper = RegressionStopper()  # window=3
+            stopper = RegressionStopper(window=5)  # window=5
+            ```
+        """
+        if window < 1:
+            raise ConfigurationError(
+                f"RegressionStopper window must be >= 1, got {window}",
+                field="window",
+                value=window,
+                constraint="Must be >= 1",
+            )
+        self.window = window
+        self._score_history: list[float] = []
+
+    def setup(self) -> None:
+        """Reset score history. Called by engine at start of each run.
+
+        Clears the internal score history so the stopper can be safely reused
+        across multiple ``evolve()`` calls with the same instance. Without this
+        reset, history from one run would bleed into the next.
+
+        Examples:
+            ```python
+            stopper = RegressionStopper()
+            # ... run evolution ...
+            stopper.setup()  # reset for next run
+            ```
+        """
+        self._score_history = []
+
+    def __call__(self, state: StopperState) -> bool:
+        """Check if evolution should stop due to score regression.
+
+        Appends the current best score to history, then compares the latest
+        score against the score from ``window`` iterations ago. Returns
+        ``False`` during the cold-start phase (fewer than ``window + 1`` calls).
+
+        Args:
+            state: Current evolution state snapshot containing best_score.
+
+        Returns:
+            True if current best score is strictly lower than the score
+            ``window`` iterations ago, False otherwise.
+
+        Examples:
+            ```python
+            stopper = RegressionStopper(window=3)
+            state = StopperState(iteration=3, best_score=0.4, ...)
+            stopper(state)  # True if prior scores were [0.5, 0.6, 0.7]
+            ```
+        """
+        self._score_history.append(state.best_score)
+        if len(self._score_history) <= self.window:
+            return False
+        current = self._score_history[-1]
+        baseline = self._score_history[-(self.window + 1)]
+        if current < baseline:
+            logger.info(
+                "stopper.regression.triggered",
+                window=self.window,
+                current_score=current,
+                baseline_score=baseline,
+            )
+            return True
+        return False
+
+
+__all__ = ["RegressionStopper"]

--- a/src/gepa_adk/adapters/stoppers/regression.py
+++ b/src/gepa_adk/adapters/stoppers/regression.py
@@ -1,12 +1,14 @@
 """Regression detection stopper for evolution termination on score decline.
 
 This module provides a RegressionStopper that terminates evolution when
-the best score consistently declines over a configurable lookback window,
-preventing wasted compute on degrading runs.
+the current best score declines compared to the score from a configurable
+lookback window ago, preventing wasted compute once performance regresses
+relative to a previous baseline.
 
 Attributes:
-    RegressionStopper (class): Stop evolution when score declines over N iterations,
-        using a bounded ``deque`` for O(1) memory regardless of run length.
+    RegressionStopper (class): Stop evolution when score declines relative to the
+        score from N iterations ago, using a bounded ``deque`` for O(1) memory
+        regardless of run length.
 
 Examples:
     Basic usage with default window:

--- a/src/gepa_adk/adapters/stoppers/regression.py
+++ b/src/gepa_adk/adapters/stoppers/regression.py
@@ -128,7 +128,7 @@ class RegressionStopper:
         )  # True (0.4 < 0.5, the baseline from window=3 ago)
         ```
 
-    Note:
+    Notes:
         Equal scores (plateau) are NOT considered regression. Only strictly
         lower scores trigger a stop.
     """
@@ -149,7 +149,7 @@ class RegressionStopper:
             stopper = RegressionStopper(window=5)  # window=5
             ```
 
-        Note:
+        Notes:
             Score history is stored in a ``deque(maxlen=window+1)`` so memory
             usage is bounded to exactly ``window + 1`` floats regardless of
             run length.

--- a/tests/contracts/test_stopper_protocol.py
+++ b/tests/contracts/test_stopper_protocol.py
@@ -6,7 +6,11 @@ method signatures, return types, and runtime checkability.
 
 import pytest
 
-from gepa_adk.adapters.stoppers import FileStopper, MaxEvaluationsStopper
+from gepa_adk.adapters.stoppers import (
+    FileStopper,
+    MaxEvaluationsStopper,
+    RegressionStopper,
+)
 from gepa_adk.domain.stopper import StopperState
 from gepa_adk.ports.stopper import StopperProtocol
 
@@ -91,6 +95,11 @@ class TestStopperProtocolRuntimeCheckable:
     def test_file_stopper_satisfies_protocol(self, tmp_path) -> None:
         """FileStopper from adapters satisfies StopperProtocol."""
         stopper = FileStopper(tmp_path / "stop_file")
+        assert isinstance(stopper, StopperProtocol)
+
+    def test_regression_stopper_satisfies_protocol(self) -> None:
+        """RegressionStopper from adapters satisfies StopperProtocol."""
+        stopper = RegressionStopper()
         assert isinstance(stopper, StopperProtocol)
 
 

--- a/tests/unit/adapters/stoppers/test_regression.py
+++ b/tests/unit/adapters/stoppers/test_regression.py
@@ -1,0 +1,313 @@
+"""Unit tests for RegressionStopper.
+
+Tests cover all acceptance criteria from Story 6.1:
+- Regression detection with default window (window=3)
+- Regression detection with custom window
+- No regression with improving scores
+- Edge case with insufficient history
+- Instance reuse safety via setup()
+- Composition with CompositeStopper
+- Protocol compliance
+"""
+
+import pytest
+
+from gepa_adk.adapters.stoppers import (
+    CompositeStopper,
+    RegressionStopper,
+    ScoreThresholdStopper,
+)
+from gepa_adk.domain.exceptions import ConfigurationError
+from gepa_adk.domain.stopper import StopperState
+from gepa_adk.ports.stopper import StopperProtocol
+
+pytestmark = pytest.mark.unit
+
+
+def make_state(best_score: float, iteration: int = 0) -> StopperState:
+    """Create a StopperState with the given best_score for testing."""
+    return StopperState(
+        iteration=iteration,
+        best_score=best_score,
+        stagnation_counter=0,
+        total_evaluations=iteration,
+        candidates_count=1,
+        elapsed_seconds=float(iteration),
+    )
+
+
+class TestRegressionStopperInitialization:
+    """Tests for RegressionStopper initialization."""
+
+    def test_init_default_window(self) -> None:
+        """RegressionStopper initializes with default window=3."""
+        stopper = RegressionStopper()
+
+        assert stopper.window == 3
+
+    def test_init_window_one(self) -> None:
+        """RegressionStopper accepts window=1."""
+        stopper = RegressionStopper(window=1)
+
+        assert stopper.window == 1
+
+    def test_init_custom_window(self) -> None:
+        """RegressionStopper accepts custom window value."""
+        stopper = RegressionStopper(window=5)
+
+        assert stopper.window == 5
+
+    def test_init_window_zero_raises_configuration_error(self) -> None:
+        """RegressionStopper raises ConfigurationError for window=0."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            RegressionStopper(window=0)
+
+        error = exc_info.value
+        assert error.field == "window"
+        assert error.value == 0
+        assert error.constraint == "Must be >= 1"
+
+    def test_init_window_negative_raises_configuration_error(self) -> None:
+        """RegressionStopper raises ConfigurationError for window=-1."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            RegressionStopper(window=-1)
+
+        error = exc_info.value
+        assert error.field == "window"
+        assert error.value == -1
+        assert error.constraint == "Must be >= 1"
+
+    def test_score_history_starts_empty(self) -> None:
+        """RegressionStopper initializes with empty score history."""
+        stopper = RegressionStopper()
+
+        assert stopper._score_history == []
+
+
+class TestRegressionStopperBehavior:
+    """Tests for RegressionStopper core stopping behavior."""
+
+    def test_insufficient_history_returns_false(self) -> None:
+        """Stopper returns False when fewer than window+1 calls have been made."""
+        stopper = RegressionStopper(window=3)
+
+        # 3 calls — fewer than window+1=4 — must all return False
+        assert stopper(make_state(0.5)) is False
+        assert stopper(make_state(0.6)) is False
+        assert stopper(make_state(0.7)) is False
+
+    def test_exactly_at_window_plus_one_regression_detected(self) -> None:
+        """Stopper returns True at exactly window+1 calls when regression present."""
+        stopper = RegressionStopper(window=3)
+
+        # 3 cold-start calls
+        stopper(make_state(0.5))
+        stopper(make_state(0.6))
+        stopper(make_state(0.7))
+        # 4th call: history=[0.5,0.6,0.7,0.4], compare 0.4 vs 0.5 → True
+        result = stopper(make_state(0.4))
+
+        assert result is True
+
+    def test_exactly_at_window_plus_one_no_regression(self) -> None:
+        """Stopper returns False at window+1 calls when no regression."""
+        stopper = RegressionStopper(window=3)
+
+        stopper(make_state(0.5))
+        stopper(make_state(0.6))
+        stopper(make_state(0.7))
+        # 4th call: compare 0.8 vs 0.5 → no regression
+        result = stopper(make_state(0.8))
+
+        assert result is False
+
+    def test_improving_scores_never_stops(self) -> None:
+        """Stopper never returns True with consistently improving scores."""
+        stopper = RegressionStopper(window=3)
+
+        scores = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        results = [stopper(make_state(s)) for s in scores]
+
+        assert all(r is False for r in results)
+
+    def test_custom_window_five_needs_six_calls(self) -> None:
+        """Stopper with window=5 requires 6 calls before any detection."""
+        stopper = RegressionStopper(window=5)
+
+        # 5 cold-start calls — all False
+        for _ in range(5):
+            assert stopper(make_state(0.9)) is False
+
+        # 6th call — first chance to detect
+        result = stopper(make_state(0.1))
+        assert result is True  # 0.1 < 0.9 (the first value)
+
+
+class TestRegressionStopperEdgeCases:
+    """Tests for boundary conditions and edge cases."""
+
+    def test_window_one_detects_single_step_regression(self) -> None:
+        """window=1 detects regression after just 2 calls."""
+        stopper = RegressionStopper(window=1)
+
+        stopper(make_state(0.8))
+        result = stopper(make_state(0.5))  # 0.5 < 0.8 → True
+
+        assert result is True
+
+    def test_window_one_no_regression_after_two_calls(self) -> None:
+        """window=1 returns False on 2nd call when no regression."""
+        stopper = RegressionStopper(window=1)
+
+        stopper(make_state(0.5))
+        result = stopper(make_state(0.8))  # 0.8 >= 0.5 → False
+
+        assert result is False
+
+    def test_plateau_scores_not_regression(self) -> None:
+        """Equal scores (plateau) do NOT trigger regression (strict less-than)."""
+        stopper = RegressionStopper(window=3)
+
+        scores = [0.8, 0.8, 0.8, 0.8]
+        results = [stopper(make_state(s)) for s in scores]
+
+        assert all(r is False for r in results)
+
+    def test_long_run_history_grows_detection_uses_lookback(self) -> None:
+        """After many calls, detection compares last vs N-window, not first."""
+        stopper = RegressionStopper(window=3)
+
+        # Build history: 0.1,0.2,...,0.9 (9 improving scores → no regression)
+        for i in range(1, 10):
+            assert stopper(make_state(i / 10.0)) is False
+
+        # Now add a score that's lower than 3 steps ago (0.9 - 3 → 0.7)
+        # history[-4] = 0.7, add 0.5 → 0.5 < 0.7 → True
+        result = stopper(make_state(0.5))
+
+        assert result is True
+
+    def test_scores_recover_then_decline(self) -> None:
+        """Score recovery followed by decline triggers regression on decline."""
+        stopper = RegressionStopper(window=3)
+
+        # history will be [0.5, 0.6, 0.7, 0.4]
+        stopper(make_state(0.5))
+        stopper(make_state(0.6))
+        stopper(make_state(0.7))
+        result = stopper(make_state(0.4))  # 0.4 < 0.5 → True
+
+        assert result is True
+
+    def test_setup_clears_history(self) -> None:
+        """setup() resets score history so stopper doesn't fire immediately after."""
+        stopper = RegressionStopper(window=3)
+
+        # Trigger regression in first run
+        stopper(make_state(0.5))
+        stopper(make_state(0.6))
+        stopper(make_state(0.7))
+        assert stopper(make_state(0.4)) is True  # triggered
+
+        # Reset for next run
+        stopper.setup()
+        assert stopper._score_history == []
+
+        # Cold start: first 3 calls must be False
+        assert stopper(make_state(0.4)) is False
+        assert stopper(make_state(0.3)) is False
+        assert stopper(make_state(0.2)) is False
+
+
+class TestRegressionStopperComposition:
+    """Tests for RegressionStopper composed with CompositeStopper."""
+
+    def test_composite_with_regression_stopper_is_protocol(self) -> None:
+        """CompositeStopper containing RegressionStopper satisfies StopperProtocol."""
+        composite = CompositeStopper(
+            [RegressionStopper(window=3), ScoreThresholdStopper(0.99)],
+            mode="any",
+        )
+
+        assert isinstance(composite, StopperProtocol)
+
+    def test_composite_any_stops_on_regression(self) -> None:
+        """CompositeStopper(mode='any') stops when RegressionStopper fires."""
+        regression = RegressionStopper(window=2)
+        composite = CompositeStopper(
+            [regression, ScoreThresholdStopper(0.99)], mode="any"
+        )
+
+        # Cold start
+        composite(make_state(0.5))
+        composite(make_state(0.6))
+        # Regression: 0.3 < 0.5 (window=2 → compare history[-1] vs history[-3])
+        result = composite(make_state(0.3))
+
+        assert result is True
+
+    def test_composite_all_short_circuit_skips_regression_history(self) -> None:
+        """Document: mode='all' short-circuits when first stopper returns False.
+
+        When RegressionStopper is listed after a stopper that frequently returns
+        False, all() short-circuits before calling RegressionStopper. The stateful
+        stopper never accumulates history and therefore never fires.
+
+        Mitigation: list RegressionStopper first in mode='all' compositions.
+        """
+        regression = RegressionStopper(window=2)
+        # ScoreThresholdStopper(0.99) returns False for scores below 0.99,
+        # causing all() to short-circuit before RegressionStopper is called.
+        composite = CompositeStopper(
+            [ScoreThresholdStopper(0.99), regression], mode="all"
+        )
+
+        for _ in range(5):
+            result = composite(make_state(0.1))  # threshold not met → short-circuits
+            assert result is False
+
+        # RegressionStopper was never called — history is empty despite 5 calls
+        assert regression._score_history == []
+
+    def test_composite_propagates_setup_to_regression_stopper(self) -> None:
+        """CompositeStopper.setup() resets nested RegressionStopper for multi-run safety."""
+        regression = RegressionStopper(window=2)
+        composite = CompositeStopper(
+            [regression, ScoreThresholdStopper(0.99)], mode="any"
+        )
+
+        # Run 1: trigger regression
+        composite(make_state(0.8))
+        composite(make_state(0.7))
+        assert composite(make_state(0.3)) is True  # regression fires
+
+        # Reset for run 2 via composite.setup()
+        composite.setup()
+        assert regression._score_history == []
+
+        # Run 2: cold start — must not fire immediately
+        assert composite(make_state(0.3)) is False  # history cleared, cold start
+        assert (
+            composite(make_state(0.2)) is False
+        )  # still cold start (window=2 needs 3 calls)
+        assert (
+            composite(make_state(0.1)) is True
+        )  # now window+1 calls, regression detected
+
+
+class TestRegressionStopperProtocolCompliance:
+    """Tests verifying RegressionStopper satisfies StopperProtocol."""
+
+    def test_satisfies_stopper_protocol(self) -> None:
+        """RegressionStopper instance satisfies StopperProtocol."""
+        stopper = RegressionStopper()
+
+        assert isinstance(stopper, StopperProtocol)
+
+    def test_call_returns_bool(self) -> None:
+        """RegressionStopper __call__ returns a boolean value."""
+        stopper = RegressionStopper()
+
+        result = stopper(make_state(0.5))
+
+        assert isinstance(result, bool)

--- a/tests/unit/adapters/stoppers/test_regression.py
+++ b/tests/unit/adapters/stoppers/test_regression.py
@@ -173,7 +173,7 @@ class TestRegressionStopperEdgeCases:
 
         assert all(r is False for r in results)
 
-    def test_long_run_history_grows_detection_uses_lookback(self) -> None:
+    def test_long_run_detection_uses_correct_lookback(self) -> None:
         """After many calls, detection compares last vs N-window, not first."""
         stopper = RegressionStopper(window=3)
 

--- a/tests/unit/adapters/stoppers/test_regression.py
+++ b/tests/unit/adapters/stoppers/test_regression.py
@@ -81,7 +81,7 @@ class TestRegressionStopperInitialization:
         """RegressionStopper initializes with empty score history."""
         stopper = RegressionStopper()
 
-        assert stopper._score_history == []
+        assert len(stopper._score_history) == 0
 
 
 class TestRegressionStopperBehavior:
@@ -211,7 +211,7 @@ class TestRegressionStopperEdgeCases:
 
         # Reset for next run
         stopper.setup()
-        assert stopper._score_history == []
+        assert len(stopper._score_history) == 0
 
         # Cold start: first 3 calls must be False
         assert stopper(make_state(0.4)) is False
@@ -267,7 +267,7 @@ class TestRegressionStopperComposition:
             assert result is False
 
         # RegressionStopper was never called — history is empty despite 5 calls
-        assert regression._score_history == []
+        assert len(regression._score_history) == 0
 
     def test_composite_propagates_setup_to_regression_stopper(self) -> None:
         """CompositeStopper.setup() resets nested RegressionStopper for multi-run safety."""
@@ -283,7 +283,7 @@ class TestRegressionStopperComposition:
 
         # Reset for run 2 via composite.setup()
         composite.setup()
-        assert regression._score_history == []
+        assert len(regression._score_history) == 0
 
         # Run 2: cold start — must not fire immediately
         assert composite(make_state(0.3)) is False  # history cleared, cold start

--- a/tests/unit/adapters/test_adapter_reexports.py
+++ b/tests/unit/adapters/test_adapter_reexports.py
@@ -169,7 +169,7 @@ REEXPORT_CASES: list[tuple[str, str, str]] = [
         "clone_workflow_with_overrides",
     ),
     ("WorkflowAgentType", "gepa_adk.adapters.workflow.workflow", "WorkflowAgentType"),
-    # Stoppers (unchanged)
+    # Stoppers
     ("RegressionStopper", "gepa_adk.adapters.stoppers", "RegressionStopper"),
     ("TimeoutStopper", "gepa_adk.adapters.stoppers", "TimeoutStopper"),
     # Media

--- a/tests/unit/adapters/test_adapter_reexports.py
+++ b/tests/unit/adapters/test_adapter_reexports.py
@@ -170,6 +170,7 @@ REEXPORT_CASES: list[tuple[str, str, str]] = [
     ),
     ("WorkflowAgentType", "gepa_adk.adapters.workflow.workflow", "WorkflowAgentType"),
     # Stoppers (unchanged)
+    ("RegressionStopper", "gepa_adk.adapters.stoppers", "RegressionStopper"),
     ("TimeoutStopper", "gepa_adk.adapters.stoppers", "TimeoutStopper"),
     # Media
     (


### PR DESCRIPTION
Evolution had no mechanism to detect when scores were consistently degrading. Without regression detection, compute was wasted on runs that were actively getting worse rather than improving. This adds `RegressionStopper`, a stateful stopper that terminates evolution when `best_score` at iteration N is strictly lower than at iteration N-window.

- Add `RegressionStopper` with configurable `window` parameter (default 3); cold-starts for `window` iterations before any detection is possible
- Propagate `setup()` through `CompositeStopper` to stateful child stoppers, making nested `RegressionStopper` safe across multi-run reuse
- Export `RegressionStopper` through the full chain (`stoppers` → `adapters` → `gepa_adk` top-level)
- Add 23 unit tests, contract test entry, and a dedicated `stoppers.md` section documenting cold-start semantics, plateau handling, and `mode="all"` short-circuit ordering caveat

Test: `uv run pytest tests/unit/adapters/stoppers/test_regression.py tests/contracts/test_stopper_protocol.py -v`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `composite.py` `setup()` propagation — iterates children via `getattr` to avoid hard dependency on the method; verify the approach is consistent with how `async_engine.py` handles `setup()` on top-level stoppers
- `mode="all"` short-circuit caveat is documented in `CompositeStopper.__call__` docstring and `stoppers.md`; a test (`test_composite_all_short_circuit_skips_regression_history`) documents the limitation rather than fixing it — confirm this is the right trade-off

### Related
- Story 6.1: `_bmad-output/implementation-artifacts/6-1-regression-detection-stopper.md`
- Epic 6: Evolution Analytics (`_bmad-output/planning-artifacts/epics.md`)