### PR TITLE
chore(docs): use Notes section header and reconcile docvet with ruff D417

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,14 @@ unresolved-attribute = "ignore"
 [tool.docvet]
 fail-on = ["enrichment", "freshness", "coverage", "griffe", "presence"]
 
+[tool.docvet.enrichment]
+# ruff D417 requires *args/**kwargs to be documented; include them in
+# docvet's signature-vs-Args agreement check so the two don't conflict.
+exclude-args-kwargs = false
+# Document **kwargs inline in Args (ruff D417 convention) rather than in
+# a separate Other Parameters section.
+require-other-parameters = false
+
 [tool.docvet.presence]
 min-coverage = 100.0
 
@@ -173,7 +181,8 @@ dev = [
     # See: https://github.com/psf/requests/issues/issues
     "requests>=2.32.0,!=2.32.5",
     "uv-secure>=0.17.0",
-    "docvet[lsp,mcp]>=1.11.0",
+    "docvet[lsp,mcp]>=1.15.1",
+    "griffe>=2.0.2",
 ]
 
 [tool.pytest.ini_options]

--- a/src/gepa_adk/__init__.py
+++ b/src/gepa_adk/__init__.py
@@ -78,7 +78,7 @@ See Also:
     - [`gepa_adk.domain.models`][gepa_adk.domain.models]: Detailed model implementations.
     - [`gepa_adk.domain.exceptions`][gepa_adk.domain.exceptions]: Exception hierarchy.
 
-Note:
+Notes:
     This is the main entry point for the gepa-adk package. Domain models
     are re-exported here for convenient top-level access.
 """

--- a/src/gepa_adk/adapters/__init__.py
+++ b/src/gepa_adk/adapters/__init__.py
@@ -47,7 +47,7 @@ Compatibility:
     GenerateContentConfig) have identical import paths in 1.20.0 and later.
     CI enforces compatibility via a version matrix in tests.yml.
 
-Note:
+Notes:
     This layer ONLY contains adapters - they import from ports/ and domain/
     but never the reverse. This maintains hexagonal architecture boundaries.
 """

--- a/src/gepa_adk/adapters/agents/reflection_agents.py
+++ b/src/gepa_adk/adapters/agents/reflection_agents.py
@@ -259,7 +259,7 @@ def create_schema_reflection_agent(model: str) -> LlmAgent:
         - [`validate_output_schema`][gepa_adk.utils.schema_tools.validate_output_schema]:
           Validation tool function.
 
-    Note:
+    Notes:
         The agent uses `output_key` for text output extraction, not `output_schema`.
         This avoids ADK's limitation where tools and output_schema cannot be used
         together. The agent returns plain text (the Pydantic class definition).
@@ -313,7 +313,7 @@ def create_config_reflection_agent(model: str) -> LlmAgent:
         - [`CONFIG_REFL`][gepa_adk.adapters.agents.reflection_agents.CONFIG_REFLECTION_INSTRUCTION]:
           Config instruction template.
 
-    Note:
+    Notes:
         The agent does not use validation tools because config validation
         is built into the GenerateContentConfigHandler.apply() method.
         Invalid configs are gracefully rejected there.

--- a/src/gepa_adk/adapters/components/__init__.py
+++ b/src/gepa_adk/adapters/components/__init__.py
@@ -39,7 +39,7 @@ See Also:
     - [`gepa_adk.adapters.evolution`][gepa_adk.adapters.evolution]: Adapters that use component
         handlers during evolution.
 
-Note:
+Notes:
     This package centralizes component handler registration for evolution surfaces.
 """
 

--- a/src/gepa_adk/adapters/components/component_handlers.py
+++ b/src/gepa_adk/adapters/components/component_handlers.py
@@ -54,7 +54,7 @@ See Also:
     - [`adk_adapter`][gepa_adk.adapters.evolution.adk_adapter]:
       Usage in ADKAdapter._apply_candidate().
 
-Note:
+Notes:
     This module follows hexagonal architecture - it imports the protocol
     from ports/ and implements concrete handlers in adapters/.
 """
@@ -122,7 +122,7 @@ class ComponentHandlerRegistry:
         - [`get_handler()`][gepa_adk.adapters.components.component_handlers.get_handler]:
             Convenience function for default registry.
 
-    Note:
+    Notes:
         A default registry instance is available as `component_handlers`
         module variable, with convenience functions `get_handler()` and
         `register_handler()`.
@@ -137,7 +137,7 @@ class ComponentHandlerRegistry:
             assert not registry.has("instruction")
             ```
 
-        Note:
+        Notes:
             Creates an empty internal dict for handler storage.
         """
         self._handlers: dict[str, ComponentHandler] = {}
@@ -160,7 +160,7 @@ class ComponentHandlerRegistry:
             registry.register("output_schema", OutputSchemaHandler())
             ```
 
-        Note:
+        Notes:
             Overwrites existing handler if name already registered.
             Logs a debug message on replacement.
         """
@@ -229,7 +229,7 @@ class ComponentHandlerRegistry:
                 handler = registry.get("instruction")
             ```
 
-        Note:
+        Notes:
             Outputs False for empty/None names (no ValueError).
             This allows safe checking without exception handling.
         """
@@ -249,7 +249,7 @@ class ComponentHandlerRegistry:
             # ["generate_content_config", "instruction", "output_schema"]
             ```
 
-        Note:
+        Notes:
             Output is sorted alphabetically for consistent error messages
             and validation feedback.
         """
@@ -271,7 +271,7 @@ class InstructionHandler:
         handler.restore(agent, original)  # Back to "Be helpful"
         ```
 
-    Note:
+    Notes:
         All state is stored in the agent object - handler is stateless.
         No instance attributes are maintained.
     """
@@ -357,7 +357,7 @@ class GenerateContentConfigHandler:
         handler.restore(agent, original_config)
         ```
 
-    Note:
+    Notes:
         All state is stored in the agent object - handler is stateless.
         On invalid config, logs warning and keeps original.
     """
@@ -397,7 +397,7 @@ class GenerateContentConfigHandler:
             # agent.generate_content_config.temperature is now 0.5
             ```
 
-        Note:
+        Notes:
             On deserialization or validation failure, logs warning and
             keeps original config. Never raises exceptions.
         """
@@ -486,7 +486,7 @@ class OutputSchemaHandler:
         handler.restore(agent, original_schema)
         ```
 
-    Note:
+    Notes:
         Applies serialize_pydantic_schema and deserialize_schema utilities.
         On invalid schema text, keeps original and logs warning.
         When constraints are set, validates proposed schemas before applying.
@@ -516,7 +516,7 @@ class OutputSchemaHandler:
             handler.set_constraints(None)  # Clear constraints
             ```
 
-        Note:
+        Notes:
             Once set, constraints are checked during apply() - proposed schemas
             that violate constraints will be rejected and the original kept.
         """
@@ -577,7 +577,7 @@ class OutputSchemaHandler:
             )
             ```
 
-        Note:
+        Notes:
             On deserialization failure, logs warning and keeps original.
             On constraint violation, keeps original.
             Never raises exceptions - graceful degradation.
@@ -668,7 +668,7 @@ def get_handler(name: str) -> ComponentHandler:
         - [gepa_adk.adapters.components.component_handlers.ComponentHandlerRegistry.get][]:
           Underlying registry method.
 
-    Note:
+    Notes:
         Shortcut for component_handlers.get(name).
     """
     return component_handlers.get(name)
@@ -695,7 +695,7 @@ def register_handler(name: str, handler: ComponentHandler) -> None:
         - [gepa_adk.adapters.components.component_handlers.ComponentHandlerRegistry.register][]:
           Underlying registry method.
 
-    Note:
+    Notes:
         Shortcut for component_handlers.register(name, handler).
     """
     component_handlers.register(name, handler)

--- a/src/gepa_adk/adapters/config_adapter.py
+++ b/src/gepa_adk/adapters/config_adapter.py
@@ -39,7 +39,7 @@ See Also:
     - [`ConfigValidationError`][gepa_adk.domain.exceptions.ConfigValidationError]:
       Error type for invalid configs.
 
-Note:
+Notes:
     This module is in the adapters/ layer and may import external library types
     (google.genai.types) directly following hexagonal architecture.
 """
@@ -114,7 +114,7 @@ def serialize_generate_config(config: GenerateContentConfig | None) -> str:
         # top_p: 0.9
         ```
 
-    Note:
+    Notes:
         Output is parseable by yaml.safe_load() and includes only evolvable
         parameters that have non-None values.
     """
@@ -189,7 +189,7 @@ def deserialize_generate_config(
         assert merged.top_p == 0.9  # Preserved from existing
         ```
 
-    Note:
+    Notes:
         Does NOT validate parameter constraints - use validate_generate_config()
         separately. This allows inspection of invalid values before rejection.
     """
@@ -282,7 +282,7 @@ def validate_generate_config(config_dict: dict[str, Any]) -> list[str]:
         assert errors == []  # Warning logged, but no error
         ```
 
-    Note:
+    Notes:
         Only validates known evolvable parameters. Unknown parameters are
         logged as warnings but accepted (may be model-specific).
     """

--- a/src/gepa_adk/adapters/evolution/__init__.py
+++ b/src/gepa_adk/adapters/evolution/__init__.py
@@ -36,7 +36,7 @@ See Also:
     - [`gepa_adk.adapters.components`][gepa_adk.adapters.components]: Component handlers
         for evolvable surfaces.
 
-Note:
+Notes:
     This package groups ADK adapter implementations by evolution strategy.
 """
 

--- a/src/gepa_adk/adapters/evolution/adk_adapter.py
+++ b/src/gepa_adk/adapters/evolution/adk_adapter.py
@@ -12,7 +12,7 @@ Terminology:
     - **trajectory**: Execution record {tool_calls, tokens, error} (deterministic)
     - **proposed_component_text**: The improved text for the same component
 
-Note:
+Notes:
     This adapter bridges GEPA's evaluation patterns to ADK's agent/runner
     architecture, handling instruction overrides, trace capture, and session
     management per ADK conventions.
@@ -110,7 +110,7 @@ class ADKAdapter:
         result = await adapter.evaluate(batch, candidate)
         ```
 
-    Note:
+    Notes:
         Adheres to AsyncGEPAAdapter[dict[str, Any], ADKTrajectory, str] protocol.
         All methods are async and follow ADK's async-first patterns.
     """
@@ -171,7 +171,7 @@ class ADKAdapter:
             adapter = ADKAdapter(agent, scorer, executor, proposer=my_proposer)
             ```
 
-        Note:
+        Notes:
             Caches the agent's original instruction and restores it after
             each evaluation to ensure no side effects between evaluations.
             Proposer construction is handled by the composition root
@@ -244,7 +244,7 @@ class ADKAdapter:
         constraint leakage between evolution runs. Should be called when the
         adapter is no longer needed.
 
-        Note:
+        Notes:
             OutputSchemaHandler is a singleton, so constraints set during one
             evolution run could affect subsequent runs if not cleared.
         """
@@ -297,7 +297,7 @@ class ADKAdapter:
             assert len(result.trajectories) == len(batch)
             ```
 
-        Note:
+        Notes:
             Original instruction is restored after evaluation completes,
             even if an exception occurs during evaluation.
             Evaluations run in parallel with concurrency controlled by
@@ -429,7 +429,7 @@ class ADKAdapter:
         Raises:
             KeyError: If candidate contains unregistered component name.
 
-        Note:
+        Notes:
             Original values are captured before overwriting via ComponentHandler
             registry dispatch instead of hardcoded if/elif logic. Each handler's
             apply() method sets the new value and returns the original for
@@ -469,7 +469,7 @@ class ADKAdapter:
         Raises:
             KeyError: If originals contains unregistered component name.
 
-        Note:
+        Notes:
             Operates via ComponentHandler registry for dispatch. Each handler's
             restore() method reinstates the original value. Should always
             be called in finally block to ensure restoration even if
@@ -503,7 +503,7 @@ class ADKAdapter:
             List of ToolCallRecord instances with tool name, arguments,
             and result (if available).
 
-        Note:
+        Notes:
             Scans function_call and function_response parts from
             Event.actions.function_calls if present. Tool calls without
             responses are still recorded. Handles both real ADK Events
@@ -578,7 +578,7 @@ class ADKAdapter:
             List of dictionaries containing state delta information.
             Each dict has 'key' and 'value' fields from Event.state_delta.
 
-        Note:
+        Notes:
             Skips events with None state_delta attributes. State deltas
             capture changes to session or agent state during execution.
         """
@@ -604,7 +604,7 @@ class ADKAdapter:
         Returns:
             TokenUsage instance if usage metadata found, None otherwise.
 
-        Note:
+        Notes:
             Searches for usage_metadata on final response events. Returns
             the last found usage data (most complete metrics).
         """
@@ -638,7 +638,7 @@ class ADKAdapter:
             ADKTrajectory with tool calls, state deltas, token usage,
             final output, and error (if any).
 
-        Note:
+        Notes:
             Synthesizes trajectory by delegating to extract_trajectory utility
             with configured trajectory_config. This is the complete execution
             record for one batch example.
@@ -671,7 +671,7 @@ class ADKAdapter:
             Tuple of (output_text, score, trajectory_or_none, metadata_or_none).
             On failure, returns ("", 0.0, error_trajectory, None).
 
-        Note:
+        Notes:
             Semaphore-controlled wrapper around single example evaluation.
             Called from evaluate() for each example in the batch to ensure
             at most max_concurrent_evals evaluations run simultaneously.
@@ -756,7 +756,7 @@ class ADKAdapter:
         Returns:
             Content object with text and video parts, or None if no videos present.
 
-        Note:
+        Notes:
             Sequences video loading via VideoBlobService then Content assembly.
             Text part is included first, followed by video parts in order.
         """
@@ -801,7 +801,7 @@ class ADKAdapter:
         Raises:
             RuntimeError: If agent execution fails.
 
-        Note:
+        Notes:
             Delegates to AgentExecutor for unified execution path.
             When capture_events=True, collects all events for trace extraction.
             Supports multimodal inputs via 'videos' field in example.
@@ -871,7 +871,7 @@ class ADKAdapter:
             assert trial["feedback"]["score"] == 0.75
             ```
 
-        Note:
+        Notes:
             Operates on eval_batch trajectories (capture_traces=True required).
             Dataset format is compatible with proposer's trial-based interface.
             Scorer metadata (feedback_text, feedback_dimensions) from
@@ -1032,7 +1032,7 @@ class ADKAdapter:
             # new_texts["instruction"] contains proposed component text
             ```
 
-        Note:
+        Notes:
             Delegates to the injected proposer for actual mutation
             generation. Falls back gracefully when no trials available.
         """

--- a/src/gepa_adk/adapters/evolution/multi_agent.py
+++ b/src/gepa_adk/adapters/evolution/multi_agent.py
@@ -6,7 +6,7 @@ session state sharing between agents during evaluation. Uses ``@overload``
 with ``Literal[True]``/``Literal[False]`` on ``capture_events`` to provide
 precise return type narrowing for evaluation methods.
 
-Note:
+Notes:
     The MultiAgentAdapter coordinates evaluation of multiple agents as a unified pipeline.
     This adapter bridges GEPA evaluation patterns to Google ADK's multi-agent
     architecture, using SequentialAgent for session state sharing and enabling
@@ -141,7 +141,7 @@ class MultiAgentAdapter:
         )
         ```
 
-    Note:
+    Notes:
         Adheres to AsyncGEPAAdapter[dict[str, Any], MultiAgentTrajectory, str] protocol.
         All methods are async and follow ADK's async-first patterns.
 
@@ -257,7 +257,7 @@ class MultiAgentAdapter:
             )
             ```
 
-        Note:
+        Notes:
             Clones agents during evaluation to apply candidate instructions.
             Original agents are never mutated.
         """
@@ -336,7 +336,7 @@ class MultiAgentAdapter:
         Raises:
             ValueError: If validation fails with descriptive error message.
 
-        Note:
+        Notes:
             Called during __init__ to catch configuration errors early.
         """
         agent_names = set(self.agents.keys())
@@ -402,7 +402,7 @@ class MultiAgentAdapter:
             # originals["generator.instruction"] contains original instruction
             ```
 
-        Note:
+        Notes:
             Returns originals dict for use with _restore_agents(). Does not
             modify self.agents - modifications are applied in-place to agent
             objects which are later cloned for pipeline execution.
@@ -450,7 +450,7 @@ class MultiAgentAdapter:
             RestoreError: If one or more components fail to restore, containing
                 list of (qualified_name, exception) pairs.
 
-        Note:
+        Notes:
             Always attempts to restore all components even if some fail,
             to minimize state corruption. Uses try/except for each component.
         """
@@ -524,7 +524,7 @@ class MultiAgentAdapter:
             # pipeline is LoopAgent with max_iterations=3 preserved
             ```
 
-        Note:
+        Notes:
             Only instruction components are applied via cloning. Other components
             are inherited from the (pre-modified) original agents.
             See evaluate() for the full execution flow.
@@ -610,7 +610,7 @@ class MultiAgentAdapter:
             # output == "def foo(): ..."
             ```
 
-        Note:
+        Notes:
             Outputs are saved to session state via the agent's output_key property.
             When share_session=True, later agents can access earlier outputs via
             template strings like {output_key} in their instructions. When
@@ -635,7 +635,7 @@ class MultiAgentAdapter:
         Returns:
             Unique session identifier string.
 
-        Note:
+        Notes:
             Outputs unique session identifiers using timestamp and random components.
         """
         import time
@@ -649,9 +649,9 @@ class MultiAgentAdapter:
         Args:
             session_id: Session identifier to clean up.
 
-        Note:
-            Optional cleanup method. Currently a no-op. Future implementations
-            may delete sessions from persistent storage.
+        Notes:
+            Currently a no-op; sessions are in-memory and cleaned automatically.
+            Future implementations may delete sessions from persistent storage.
         """
         # No-op for now - sessions are in-memory and cleaned up automatically
         pass
@@ -701,7 +701,7 @@ class MultiAgentAdapter:
             assert len(result.trajectories) == len(batch)
             ```
 
-        Note:
+        Notes:
             Orchestrates evaluation by applying candidate components to agents,
             building a SequentialAgent pipeline with cloned agents, then restoring
             original agent state. Primary agent's output is scored.
@@ -854,7 +854,7 @@ class MultiAgentAdapter:
             Tuple of (output_text, score, trajectory_or_none, metadata, input_text).
             On failure, returns ("", 0.0, error_trajectory, None, input_text).
 
-        Note:
+        Notes:
             Orchestrates single example evaluation with semaphore-controlled concurrency.
             Union return from ``_run_single_example`` is narrowed by
             ``@overload`` declarations using ``Literal[True]``/``Literal[False]``
@@ -996,7 +996,7 @@ class MultiAgentAdapter:
         Raises:
             RuntimeError: If pipeline execution fails.
 
-        Note:
+        Notes:
             Orchestrates execution based on session sharing mode. When
             share_session=False, executes agents independently with isolated
             sessions. When share_session=True, uses SequentialAgent pipeline.
@@ -1053,7 +1053,7 @@ class MultiAgentAdapter:
         Returns:
             Tuple of (output, events, state) or (output, state).
 
-        Note:
+        Notes:
             Uses unified AgentExecutor when available (FR-002), otherwise
             falls back to legacy execution via direct Runner calls.
         """
@@ -1175,7 +1175,7 @@ class MultiAgentAdapter:
             Tuple of (output, events, state) or (output, state).
             Returns the primary agent's output.
 
-        Note:
+        Notes:
             Orchestrates independent execution of each agent with its own session.
             State is not shared between agents. The primary agent's output is returned.
             Agents are cloned with candidate instructions to avoid mutation.
@@ -1297,7 +1297,7 @@ class MultiAgentAdapter:
             TokenUsage with summed totals if any agent has usage data,
             None if no usage data available.
 
-        Note:
+        Notes:
             Sums input, output, and total tokens across all agents to provide
             pipeline-level token consumption metrics.
         """
@@ -1345,7 +1345,7 @@ class MultiAgentAdapter:
             MultiAgentTrajectory with per-agent trajectories, pipeline output,
             aggregated token usage, and error (if any).
 
-        Note:
+        Notes:
             Organizes trajectory data by extracting individual agent trajectories
             from events and aggregating token usage across all agents.
         """
@@ -1417,7 +1417,7 @@ class MultiAgentAdapter:
             assert "generator_instruction" in dataset
             ```
 
-        Note:
+        Notes:
             Operates on eval_batch trajectories (capture_traces=True required).
             Dataset format is compatible with MutationProposer interface.
         """
@@ -1506,7 +1506,7 @@ class MultiAgentAdapter:
             - feedback: score (mandatory), feedback_text (mandatory if available)
             - trajectory: input, output (mandatory), component context
 
-        Note:
+        Notes:
             Aligns with whitepaper requirements: score + feedback_text are the
             minimum required fields. Extra metadata (dimensions, guidance) is
             passed through when available.
@@ -1575,7 +1575,7 @@ class MultiAgentAdapter:
             # proposals contains improved instructions based on feedback
             ```
 
-        Note:
+        Notes:
             Delegates to the injected proposer for actual mutation
             generation. Falls back gracefully when dataset is empty.
         """

--- a/src/gepa_adk/adapters/execution/__init__.py
+++ b/src/gepa_adk/adapters/execution/__init__.py
@@ -28,7 +28,7 @@ See Also:
     - [`gepa_adk.adapters.evolution`][gepa_adk.adapters.evolution]: Adapters that depend on
         execution infrastructure.
 
-Note:
+Notes:
     This package encapsulates agent execution and trial-building infrastructure.
 """
 

--- a/src/gepa_adk/adapters/execution/agent_executor.py
+++ b/src/gepa_adk/adapters/execution/agent_executor.py
@@ -38,7 +38,7 @@ See Also:
     - [`gepa_adk.ports.agent_executor`][gepa_adk.ports.agent_executor]:
         Protocol and type definitions.
 
-Note:
+Notes:
     This adapter follows hexagonal architecture principles, implementing
     the AgentExecutorProtocol from the ports layer.
 """
@@ -81,7 +81,7 @@ class SessionNotFoundError(EvolutionError):
             print(f"Session not found: {e.session_id}")
         ```
 
-    Note:
+    Notes:
         Arises only from strict existence-checking paths like _get_session().
         The execute_agent() method uses get-or-create semantics and will not
         raise this exception.
@@ -130,7 +130,7 @@ class AgentExecutor:
         executor = AgentExecutor(session_service=session_service)
         ```
 
-    Note:
+    Notes:
         Adapter implements AgentExecutorProtocol for dependency injection
         and testing. All ADK-specific logic is encapsulated here.
     """
@@ -160,7 +160,7 @@ class AgentExecutor:
             executor = AgentExecutor(app_name="my_app")
             ```
 
-        Note:
+        Notes:
             Creates a shared executor that uses the session service for all
             agent executions, allowing session state to be shared between
             executions when desired.
@@ -183,7 +183,7 @@ class AgentExecutor:
         Returns:
             Created ADK Session object.
 
-        Note:
+        Notes:
             Optional session state enables template variable substitution in
             agent instructions (e.g., {component_text} and {trials}).
         """
@@ -223,7 +223,7 @@ class AgentExecutor:
         Raises:
             SessionNotFoundError: If the session does not exist.
 
-        Note:
+        Notes:
             Only performs strict existence checks for sessions that must
             already exist. Callers use this to fail fast instead of creating
             a new session. For get-or-create semantics, use _get_or_create_session.
@@ -265,7 +265,7 @@ class AgentExecutor:
         Returns:
             ADK Session object (existing or newly created).
 
-        Note:
+        Notes:
             Only applies initial state when creating new sessions. Existing
             sessions retain their current state regardless of session_state
             parameter.
@@ -322,7 +322,7 @@ class AgentExecutor:
         Returns:
             Modified agent copy (or original if no overrides).
 
-        Note:
+        Notes:
             Original agent is preserved by creating a shallow copy with
             overridden attributes. The original agent is never modified.
         """
@@ -376,7 +376,7 @@ class AgentExecutor:
         Returns:
             Content object for agent execution.
 
-        Note:
+        Notes:
             Serves as the central point for Content assembly, supporting
             both text-only (backward compatible) and multimodal inputs.
         """
@@ -409,7 +409,7 @@ class AgentExecutor:
         Returns:
             List of captured ADK events.
 
-        Note:
+        Notes:
             Orchestrates the core Runner.run_async() loop, capturing all
             events for later output extraction.
         """
@@ -449,7 +449,7 @@ class AgentExecutor:
         Returns:
             Tuple of (captured_events, timed_out).
 
-        Note:
+        Notes:
             On timeout, returns partial events captured before timeout.
             Uses asyncio.timeout for cancellation.
         """
@@ -488,7 +488,7 @@ class AgentExecutor:
         Returns:
             Extracted output string, or None if no output found.
 
-        Note:
+        Notes:
             Output extraction prioritizes state-based approach (using
             output_key), then falls back to event-based extraction.
         """
@@ -601,7 +601,7 @@ class AgentExecutor:
             )
             ```
 
-        Note:
+        Notes:
             Optional typing (Any) is used for agent parameter to avoid
             coupling to ADK types in the ports layer. Implementations
             should validate that the agent is a valid LlmAgent.

--- a/src/gepa_adk/adapters/execution/trial_builder.py
+++ b/src/gepa_adk/adapters/execution/trial_builder.py
@@ -35,7 +35,7 @@ See Also:
     - [`gepa_adk.adapters.evolution.multi_agent`][gepa_adk.adapters.evolution.multi_agent]:
       Uses TrialBuilder for multi-agent pipeline trials.
 
-Note:
+Notes:
     This implements the GEPA whitepaper trial structure where score and
     feedback_text are mandatory, with optional extras like feedback_dimensions
     and feedback_guidance passed through when available.
@@ -113,7 +113,7 @@ def normalize_feedback(
         # {"score": 1.0, "feedback_text": ""}
         ```
 
-    Note:
+    Notes:
         Score parameter always takes precedence over any "score" key in dict.
         Field mapping applies: "dimension_scores" → "dimensions",
         "actionable_guidance" → "guidance". Non-string feedback_text values
@@ -217,7 +217,7 @@ class TrialBuilder:
         - [`build_feedback`][gepa_adk.adapters.execution.trial_builder.TrialBuilder.build_feedback]:
           Build just the feedback dict.
 
-    Note:
+    Notes:
         All optional metadata fields are validated before inclusion to prevent
         malformed data from propagating to reflection prompts.
     """
@@ -230,7 +230,7 @@ class TrialBuilder:
             builder = TrialBuilder()
             ```
 
-        Note:
+        Notes:
             Creates a module-scoped logger for metadata passthrough debugging.
         """
         self._logger = structlog.get_logger(__name__)
@@ -284,7 +284,7 @@ class TrialBuilder:
             assert "feedback_text" in feedback
             ```
 
-        Note:
+        Notes:
             Only non-empty strings and dicts are included to keep feedback clean.
         """
         # Use normalize_feedback for consistent field mapping
@@ -369,7 +369,7 @@ class TrialBuilder:
             assert trial["trajectory"]["component"] == "counter"
             ```
 
-        Note:
+        Notes:
             Optional input is only included in trajectory when not None,
             supporting pipelines where input context is implicit.
         """

--- a/src/gepa_adk/adapters/media/__init__.py
+++ b/src/gepa_adk/adapters/media/__init__.py
@@ -24,7 +24,7 @@ See Also:
     - [`gepa_adk.ports.video_blob_service`][gepa_adk.ports.video_blob_service]:
         VideoBlobServiceProtocol that VideoBlobService implements.
 
-Note:
+Notes:
     This package provides multimodal media adapters for video blob services.
 """
 

--- a/src/gepa_adk/adapters/media/video_blob_service.py
+++ b/src/gepa_adk/adapters/media/video_blob_service.py
@@ -30,7 +30,7 @@ See Also:
     - [`gepa_adk.ports.video_blob_service`][gepa_adk.ports.video_blob_service]:
         Protocol definition.
 
-Note:
+Notes:
     This adapter follows hexagonal architecture principles, implementing
     the VideoBlobServiceProtocol from the ports layer. ADK types (Part)
     are only imported and used within this adapter layer.
@@ -92,7 +92,7 @@ class VideoBlobService:
             print(f"Invalid: {e.video_path}")
         ```
 
-    Note:
+    Notes:
         Adapter implements VideoBlobServiceProtocol for dependency injection
         and testing. All ADK-specific Part creation is encapsulated here.
     """
@@ -107,7 +107,7 @@ class VideoBlobService:
             service = VideoBlobService()
             ```
 
-        Note:
+        Notes:
             Creates a service instance with a bound logger for video
             operations. No external dependencies are required.
         """
@@ -125,7 +125,7 @@ class VideoBlobService:
         Returns:
             Detected MIME type string (e.g., "video/mp4").
 
-        Note:
+        Notes:
             Scans file extension only, not file content. Falls back to
             "application/octet-stream" for unknown types.
         """
@@ -155,7 +155,7 @@ class VideoBlobService:
             print(f"Size: {info.size_bytes}")
             ```
 
-        Note:
+        Notes:
             Operates synchronously for fast pre-validation. File content
             is not read, only metadata is checked.
         """
@@ -243,7 +243,7 @@ class VideoBlobService:
         Returns:
             Raw bytes of the video file.
 
-        Note:
+        Notes:
             Spawns blocking file read in thread pool via run_in_executor
             to prevent blocking the event loop during large file reads.
         """
@@ -289,7 +289,7 @@ class VideoBlobService:
             assert len(parts) == 2
             ```
 
-        Note:
+        Notes:
             Operations include async file I/O. Videos are validated before
             loading to provide early failure with clear error messages.
         """

--- a/src/gepa_adk/adapters/scoring/__init__.py
+++ b/src/gepa_adk/adapters/scoring/__init__.py
@@ -41,7 +41,7 @@ See Also:
     - [`gepa_adk.adapters.evolution`][gepa_adk.adapters.evolution]: Adapters that accept
         scorers for evaluation.
 
-Note:
+Notes:
     This package isolates critic-based scoring from other adapter concerns.
 """
 

--- a/src/gepa_adk/adapters/scoring/critic_scorer.py
+++ b/src/gepa_adk/adapters/scoring/critic_scorer.py
@@ -43,7 +43,7 @@ Examples:
     )
     ```
 
-Note:
+Notes:
     This module wraps ADK critic agents to provide structured scoring.
     When using LlmAgent with output_schema, the agent can ONLY reply and
     CANNOT use any tools (ADK constraint). For evaluations requiring tool
@@ -113,7 +113,7 @@ class SimpleCriticOutput(BaseModel):
         )
         ```
 
-    Note:
+    Notes:
         Applies to basic evaluation tasks where only a score and feedback
         are needed. For more detailed evaluations with dimension scores,
         use CriticOutput instead.
@@ -165,7 +165,7 @@ class CriticOutput(BaseModel):
         }
         ```
 
-    Note:
+    Notes:
         All critic agents using this schema must return structured JSON.
         When this schema is used as output_schema on an LlmAgent, the
         agent can ONLY reply and CANNOT use any tools. This is acceptable
@@ -383,7 +383,7 @@ def normalize_feedback(
         # {"score": 0.5, "feedback_text": ""}
         ```
 
-    Note:
+    Notes:
         Supports both SimpleCriticOutput and CriticOutput schemas for flexible
         critic integration. Extracts the "feedback" field and renames it to
         "feedback_text" for consistent trial structure. Additional fields
@@ -455,7 +455,7 @@ class CriticScorer:
         )
         ```
 
-    Note:
+    Notes:
         Adapter wraps ADK critic agents to provide structured scoring.
         Implements Scorer protocol for compatibility with evolution engine.
         Creates isolated sessions per scoring call unless session_id provided.
@@ -509,7 +509,7 @@ class CriticScorer:
             )
             ```
 
-        Note:
+        Notes:
             Creates logger with scorer context and validates agent type.
         """
         if not isinstance(critic_agent, BaseAgent):
@@ -563,7 +563,7 @@ class CriticScorer:
             )
             ```
 
-        Note:
+        Notes:
             Organizes input for critic evaluation with clearly labeled sections.
             Format is designed to give critic context for evaluation.
             Expected output is included only if provided.
@@ -622,7 +622,7 @@ class CriticScorer:
             assert metadata["feedback"] == "Good"
             ```
 
-        Note:
+        Notes:
             Obtains score and metadata from critic JSON output with validation.
             Preserves all fields from parsed JSON in metadata, not just
             the known CriticOutput schema fields. This allows for extensibility.
@@ -692,7 +692,7 @@ class CriticScorer:
         Returns:
             Extracted JSON string, or original text if extraction fails.
 
-        Note:
+        Notes:
             Operates as a minimal JSON extractor; robust implementation planned
             per GitHub issue #78.
         """
@@ -788,7 +788,7 @@ class CriticScorer:
             )
             ```
 
-        Note:
+        Notes:
             Orchestrates critic agent execution via AgentExecutor and extracts
             structured output. Creates isolated session unless session_id provided
             for state sharing.
@@ -885,7 +885,7 @@ class CriticScorer:
             )
             ```
 
-        Note:
+        Notes:
             Operates synchronously by wrapping async_score() with asyncio.run().
             Uses asyncio.run() to execute async_score(). Prefer async_score()
             for better performance in async contexts.

--- a/src/gepa_adk/adapters/selection/__init__.py
+++ b/src/gepa_adk/adapters/selection/__init__.py
@@ -47,7 +47,7 @@ See Also:
     - [`gepa_adk.ports.evaluation_policy`][gepa_adk.ports.evaluation_policy]:
         EvaluationPolicyProtocol that evaluation policies implement.
 
-Note:
+Notes:
     This package unifies candidate, component, and evaluation selection strategies.
 """
 

--- a/src/gepa_adk/adapters/selection/candidate_selector.py
+++ b/src/gepa_adk/adapters/selection/candidate_selector.py
@@ -23,7 +23,7 @@ See Also:
     - [`CandidateSelectorProtocol`][gepa_adk.ports.candidate_selector.CandidateSelectorProtocol]:
       Port protocol these adapters implement.
 
-Note:
+Notes:
     This module provides selector adapters for Pareto-aware evolution workflows.
 """
 
@@ -39,7 +39,7 @@ from gepa_adk.ports.candidate_selector import CandidateSelectorProtocol
 class ParetoCandidateSelector:
     """Sample from the Pareto front proportional to leadership frequency.
 
-    Note:
+    Notes:
         A Pareto selector emphasizes candidates that lead more examples.
 
     Attributes:
@@ -98,7 +98,7 @@ class ParetoCandidateSelector:
 class CurrentBestCandidateSelector:
     """Always select the candidate with the highest average score.
 
-    Note:
+    Notes:
         A greedy selector always exploits the best-average candidate.
 
     Examples:
@@ -133,7 +133,7 @@ class CurrentBestCandidateSelector:
 class EpsilonGreedyCandidateSelector:
     """Epsilon-greedy selection balancing exploration and exploitation.
 
-    Note:
+    Notes:
         A mixed strategy sometimes explores and otherwise exploits the best.
 
     Attributes:

--- a/src/gepa_adk/adapters/selection/component_selector.py
+++ b/src/gepa_adk/adapters/selection/component_selector.py
@@ -30,7 +30,7 @@ See Also:
     - [`ComponentSelectorProtocol`][gepa_adk.ports.component_selector.ComponentSelectorProtocol]:
       Port protocol these adapters implement.
 
-Note:
+Notes:
     These adapters implement component selection strategies that may maintain
     internal state for cycling (like RoundRobin) while remaining stateless with
     respect to the engine.
@@ -59,7 +59,7 @@ class RoundRobinComponentSelector:
         c2 = await selector.select_components(["a", "b"], 2, 0)  # ["b"]
         ```
 
-    Note:
+    Notes:
         Alternates through components sequentially, ensuring balanced evolution
         across all candidate parts.
     """
@@ -67,7 +67,7 @@ class RoundRobinComponentSelector:
     def __init__(self) -> None:
         """Initialize the round-robin selector.
 
-        Note:
+        Notes:
             Creates empty index tracking dictionary for per-candidate rotation state.
         """
         self._next_index: dict[int, int] = defaultdict(int)
@@ -93,7 +93,7 @@ class RoundRobinComponentSelector:
             selected = await selector.select_components(["a", "b"], 1, 0)
             ```
 
-        Note:
+        Notes:
             Outputs one component per call, advancing the rotation index for
             the specified candidate.
         """
@@ -125,7 +125,7 @@ class AllComponentSelector:
         # Returns ["a", "b"]
         ```
 
-    Note:
+    Notes:
         Always returns all components, enabling comprehensive mutations
         across the entire candidate in a single iteration.
     """
@@ -151,7 +151,7 @@ class AllComponentSelector:
             selected = await selector.select_components(["a", "b"], 1, 0)
             ```
 
-        Note:
+        Notes:
             Outputs the complete component list unchanged, enabling
             simultaneous evolution of all candidate parts.
         """
@@ -185,7 +185,7 @@ def create_component_selector(selector_type: str) -> ComponentSelectorProtocol:
         selector = create_component_selector("all")
         ```
 
-    Note:
+    Notes:
         Supports flexible string aliases with normalization for common
         variations (underscores, hyphens, case-insensitive).
     """

--- a/src/gepa_adk/adapters/selection/evaluation_policy.py
+++ b/src/gepa_adk/adapters/selection/evaluation_policy.py
@@ -32,7 +32,7 @@ See Also:
     - [`EvaluationPolicyProtocol`][gepa_adk.ports.evaluation_policy.EvaluationPolicyProtocol]
       for the protocol contract.
 
-Note:
+Notes:
     These policies provide strategies for selecting validation examples to
     evaluate per iteration. FullEvaluationPolicy scores all examples,
     while SubsetEvaluationPolicy scores a configurable subset with round-robin
@@ -59,7 +59,7 @@ class FullEvaluationPolicy:
     This is the default evaluation policy, providing complete visibility
     into solution performance across all validation examples.
 
-    Note:
+    Notes:
         Always returns all valset IDs, ensuring complete evaluation coverage
         each iteration.
 
@@ -88,7 +88,7 @@ class FullEvaluationPolicy:
         Returns:
             list[int]: List of all valset_ids.
 
-        Note:
+        Notes:
             Outputs the complete valset for comprehensive evaluation coverage.
 
         Examples:
@@ -112,7 +112,7 @@ class FullEvaluationPolicy:
         Raises:
             NoCandidateAvailableError: If state has no candidates.
 
-        Note:
+        Notes:
             Outputs the candidate index with the highest mean score across
             all evaluated examples.
 
@@ -147,7 +147,7 @@ class FullEvaluationPolicy:
         Returns:
             float: Mean score across all examples, or float('-inf') if no scores.
 
-        Note:
+        Notes:
             Outputs the arithmetic mean of all scores for the candidate,
             or negative infinity if no scores exist.
 
@@ -170,7 +170,7 @@ class SubsetEvaluationPolicy:
     only a subset of examples per iteration, using round-robin selection to
     ensure all examples are eventually covered.
 
-    Note:
+    Notes:
         Advances offset each iteration to provide round-robin coverage across
         the full valset over multiple iterations.
 
@@ -199,8 +199,8 @@ class SubsetEvaluationPolicy:
                 If float, evaluate this fraction of total valset.
                 Default: 0.2 (20% of valset per iteration).
 
-        Note:
-            Creates policy with initial offset of 0 for round-robin selection.
+        Notes:
+            The initial round-robin offset is 0.
         """
         self.subset_size = subset_size
         self._offset = 0
@@ -225,7 +225,7 @@ class SubsetEvaluationPolicy:
         Raises:
             ValueError: If subset_size is outside the allowed range.
 
-        Note:
+        Notes:
             Outputs a subset of valset IDs starting at the current offset,
             wrapping around if needed to provide round-robin coverage.
 
@@ -278,7 +278,7 @@ class SubsetEvaluationPolicy:
         Raises:
             NoCandidateAvailableError: If state has no candidates.
 
-        Note:
+        Notes:
             Outputs the candidate index with the highest mean score across
             evaluated examples, consistent with FullEvaluationPolicy behavior.
 
@@ -313,7 +313,7 @@ class SubsetEvaluationPolicy:
         Returns:
             float: Mean score across evaluated examples, or float('-inf') if no scores.
 
-        Note:
+        Notes:
             Outputs the arithmetic mean of scores for the candidate across
             only the examples that were actually evaluated (subset).
 

--- a/src/gepa_adk/adapters/stoppers/__init__.py
+++ b/src/gepa_adk/adapters/stoppers/__init__.py
@@ -60,7 +60,7 @@ See Also:
     - [`gepa_adk.ports.stopper`][gepa_adk.ports.stopper]: StopperProtocol interface.
     - [`gepa_adk.domain.stopper`][gepa_adk.domain.stopper]: StopperState domain model.
 
-Note:
+Notes:
     This subpackage contains adapters layer implementations. All stoppers
     implement the StopperProtocol from the ports layer.
 """

--- a/src/gepa_adk/adapters/stoppers/composite.py
+++ b/src/gepa_adk/adapters/stoppers/composite.py
@@ -34,7 +34,7 @@ Examples:
     )
     ```
 
-Note:
+Notes:
     This composite stopper is useful for building complex termination
     policies from simpler building blocks.
 
@@ -106,7 +106,7 @@ class CompositeStopper:
         )
         ```
 
-    Note:
+    Notes:
         A composite stopper can contain other composite stoppers for arbitrarily
         complex stopping conditions like "(A OR B) AND (C OR D)".
     """
@@ -143,7 +143,7 @@ class CompositeStopper:
             )
             ```
 
-        Note:
+        Notes:
             Consider using 'any' mode for fail-safe conditions (timeout OR
             resource limit) and 'all' mode for minimum requirements.
         """
@@ -195,7 +195,7 @@ class CompositeStopper:
             composite(state2)  # True (any mode - score threshold met)
             ```
 
-        Note:
+        Notes:
             Often called after each iteration. For 'any' mode, evaluation
             short-circuits on first True. For 'all' mode, short-circuits on
             first False.

--- a/src/gepa_adk/adapters/stoppers/evaluations.py
+++ b/src/gepa_adk/adapters/stoppers/evaluations.py
@@ -27,7 +27,7 @@ Examples:
     )
     ```
 
-Note:
+Notes:
     This stopper is particularly useful for controlling API costs when using
     expensive model evaluations. The evaluation count is cumulative across
     all iterations.
@@ -66,7 +66,7 @@ class MaxEvaluationsStopper:
         stopper(state)  # Returns True
         ```
 
-    Note:
+    Notes:
         Any evaluation count at or above the limit triggers a stop. This handles
         the case where batch evaluations cause the count to exceed the exact limit.
     """
@@ -81,7 +81,7 @@ class MaxEvaluationsStopper:
         Raises:
             ValueError: If max_evaluations is not positive.
 
-        Note:
+        Notes:
             Configure this value based on your API budget. Each evaluation
             typically corresponds to one model API call.
         """
@@ -100,7 +100,7 @@ class MaxEvaluationsStopper:
         Returns:
             True if total_evaluations >= max_evaluations, False otherwise.
 
-        Note:
+        Notes:
             Once this returns True, evolution should terminate to stay
             within the configured evaluation budget.
         """

--- a/src/gepa_adk/adapters/stoppers/file.py
+++ b/src/gepa_adk/adapters/stoppers/file.py
@@ -27,7 +27,7 @@ Examples:
     touch /tmp/gepa_stop  # Signal evolution to stop
     ```
 
-Note:
+Notes:
     This stopper is particularly useful for CI/CD pipelines, job schedulers,
     and external monitoring systems that cannot easily send process signals
     but can create files.
@@ -67,7 +67,7 @@ class FileStopper:
         stopper = FileStopper("/tmp/gepa_stop", remove_on_stop=True)
         ```
 
-    Note:
+    Notes:
         Any path that doesn't exist simply won't trigger a stop. Invalid paths
         are handled gracefully without raising errors.
     """
@@ -83,8 +83,8 @@ class FileStopper:
             remove_on_stop: If True, automatically remove the stop file
                 after triggering a stop. Defaults to False.
 
-        Note:
-            Configure the path based on your orchestration system. Common
+        Notes:
+            Choose a path based on your orchestration system. Common
             locations include /tmp/, /var/run/, or project-specific directories.
         """
         self.stop_file_path = Path(stop_file_path)
@@ -100,7 +100,7 @@ class FileStopper:
         Returns:
             True if the stop file exists, False otherwise.
 
-        Note:
+        Notes:
             Once this returns True, the stop file may be removed if
             remove_on_stop was enabled. Subsequent calls will return False.
         """
@@ -117,7 +117,7 @@ class FileStopper:
         Useful for resetting the stop condition before starting a new
         evolution run.
 
-        Note:
+        Notes:
             Only call this when you explicitly want to remove the stop file.
             The file is automatically removed during __call__ if remove_on_stop=True.
         """

--- a/src/gepa_adk/adapters/stoppers/signal.py
+++ b/src/gepa_adk/adapters/stoppers/signal.py
@@ -31,7 +31,7 @@ Examples:
         stopper.cleanup()
     ```
 
-Note:
+Notes:
     This stopper requires careful integration with asyncio's event loop
     for proper signal handling in async contexts.
 
@@ -97,7 +97,7 @@ class SignalStopper:
             stopper.cleanup()
         ```
 
-    Note:
+    Notes:
         Always call cleanup() after evolution completes to restore original
         signal handlers. The context manager pattern handles this automatically.
     """
@@ -118,7 +118,7 @@ class SignalStopper:
             stopper = SignalStopper(signals=[signal.SIGINT])
             ```
 
-        Note:
+        Notes:
             Call setup() before evolution starts and cleanup() after
             evolution completes to properly manage signal handlers.
         """
@@ -151,7 +151,7 @@ class SignalStopper:
                 stopper.cleanup()
             ```
 
-        Note:
+        Notes:
             On platforms where certain signals are unavailable (like Windows
             for SIGTERM), those signals are silently skipped.
         """
@@ -215,7 +215,7 @@ class SignalStopper:
             # stopper(state)  # True
             ```
 
-        Note:
+        Notes:
             Often called after each iteration. Returns True as soon as
             a signal is received.
         """
@@ -238,7 +238,7 @@ class SignalStopper:
                 stopper.cleanup()  # Restore original handlers
             ```
 
-        Note:
+        Notes:
             On platforms where certain signals are unavailable, those
             signals are silently skipped during cleanup.
         """
@@ -274,7 +274,7 @@ class SignalStopper:
                 result = await engine.run(config)
             ```
 
-        Note:
+        Notes:
             On entry, signal handlers are installed automatically.
         """
         self.setup()
@@ -293,9 +293,9 @@ class SignalStopper:
             exc_val: Exception value if an exception was raised.
             exc_tb: Exception traceback if an exception was raised.
 
-        Note:
-            Original signal handlers are restored automatically on exit,
-            even if an exception was raised.
+        Notes:
+            Restores the original signal handlers automatically on exit,
+            even when an exception is raised.
         """
         self.cleanup()
 
@@ -312,7 +312,7 @@ class SignalStopper:
                 result = engine.run(config)  # sync run
             ```
 
-        Note:
+        Notes:
             On entry, signal handlers are installed automatically.
         """
         self.setup()
@@ -331,9 +331,9 @@ class SignalStopper:
             exc_val: Exception value if an exception was raised.
             exc_tb: Exception traceback if an exception was raised.
 
-        Note:
-            Original signal handlers are restored automatically on exit,
-            even if an exception was raised.
+        Notes:
+            Restores the original signal handlers automatically on exit,
+            even when an exception is raised.
         """
         self.cleanup()
 

--- a/src/gepa_adk/adapters/stoppers/threshold.py
+++ b/src/gepa_adk/adapters/stoppers/threshold.py
@@ -17,7 +17,7 @@ Examples:
     # Use stopper in evolution config
     ```
 
-Note:
+Notes:
     This stopper is useful when you have a known target score and want to
     terminate as soon as it is reached, rather than continuing unnecessarily.
 
@@ -65,7 +65,7 @@ class ScoreThresholdStopper:
         stopper(state)  # Returns True (should stop)
         ```
 
-    Note:
+    Notes:
         Any float value can be used as threshold, including negative numbers
         for domains where scores can be negative (e.g., loss minimization).
     """
@@ -84,7 +84,7 @@ class ScoreThresholdStopper:
             stopper = ScoreThresholdStopper(-0.5)  # For negative score domains
             ```
 
-        Note:
+        Notes:
             Compared to timeout values, threshold has no restrictions on sign
             or magnitude since score domains vary by application.
         """
@@ -126,7 +126,7 @@ class ScoreThresholdStopper:
             stopper(state2)  # True
             ```
 
-        Note:
+        Notes:
             Often called after each iteration. Returns True as soon as
             the threshold is reached.
         """

--- a/src/gepa_adk/adapters/stoppers/timeout.py
+++ b/src/gepa_adk/adapters/stoppers/timeout.py
@@ -17,7 +17,7 @@ Examples:
     # Use stopper in evolution config
     ```
 
-Note:
+Notes:
     This stopper is the simplest implementation and serves as a good
     template for other stoppers.
 
@@ -63,7 +63,7 @@ class TimeoutStopper:
         stopper(state)  # Returns True (should stop)
         ```
 
-    Note:
+    Notes:
         All timeout values must be positive. Zero and negative values
         raise ValueError to prevent invalid configurations.
     """
@@ -84,7 +84,7 @@ class TimeoutStopper:
             stopper = TimeoutStopper(3600.0)  # 1 hour
             ```
 
-        Note:
+        Notes:
             Consider using reasonable timeouts for your use case. Very
             short timeouts may not allow sufficient evolution progress.
         """
@@ -128,7 +128,7 @@ class TimeoutStopper:
             stopper(state2)  # True
             ```
 
-        Note:
+        Notes:
             Often called after each iteration. Returns True as soon as
             the time limit is reached.
         """

--- a/src/gepa_adk/adapters/workflow/__init__.py
+++ b/src/gepa_adk/adapters/workflow/__init__.py
@@ -27,7 +27,7 @@ See Also:
     - [`gepa_adk.adapters.evolution`][gepa_adk.adapters.evolution]: MultiAgentAdapter that
         uses workflow utilities for multi-agent evolution.
 
-Note:
+Notes:
     Tightly integrates workflow agent utilities with the ADK adapter layer.
 """
 

--- a/src/gepa_adk/adapters/workflow/workflow.py
+++ b/src/gepa_adk/adapters/workflow/workflow.py
@@ -37,7 +37,7 @@ Examples:
     # cloned preserves structure (LoopAgent iterations, ParallelAgent concurrency)
     ```
 
-Note:
+Notes:
     This module isolates ADK-specific imports to the adapters layer,
     following hexagonal architecture principles (ADR-000).
 
@@ -89,7 +89,7 @@ def is_workflow_agent(agent: object) -> bool:
         assert is_workflow_agent(llm) is False
         ```
 
-    Note:
+    Notes:
         Only workflow agent types (SequentialAgent, LoopAgent, ParallelAgent)
         are detected. All workflow agents inherit from BaseAgent and have
         sub_agents, but type detection uses specific class checks for accuracy.
@@ -147,7 +147,7 @@ def find_llm_agents(
         assert len(agents) == 3  # Finds all agents across levels
         ```
 
-    Note:
+    Notes:
         Operates recursively with depth limiting to discover nested LlmAgents.
         Skips LlmAgents with InstructionProvider callables (non-string
         instructions). Respects max_depth to prevent infinite recursion.
@@ -273,7 +273,7 @@ def clone_workflow_with_overrides(
         assert cloned.max_iterations == 3  # Preserved!
         ```
 
-    Note:
+    Notes:
         Only instruction components are applied during cloning. Other components
         (output_schema, generate_content_config) must be applied separately via
         _apply_candidate() before cloning.
@@ -315,7 +315,7 @@ def _clone_llm_agent(
     Returns:
         Cloned LlmAgent with instruction override applied if present.
 
-    Note:
+    Notes:
         Sets parent_agent to None to avoid ADK ValueError when re-parenting.
         The new parent will set parent_agent during construction.
     """
@@ -348,7 +348,7 @@ def _clone_sequential_agent(
     Returns:
         Cloned SequentialAgent with same structure.
 
-    Note:
+    Notes:
         Sub_agents order is preserved which is critical for sequential execution.
     """
     cloned_sub_agents = [
@@ -375,7 +375,7 @@ def _clone_loop_agent(
     Returns:
         Cloned LoopAgent with max_iterations preserved.
 
-    Note:
+    Notes:
         Structural preservation of max_iterations is the primary goal of issue #215.
         This ensures loop agents execute the correct number of iterations.
     """
@@ -411,7 +411,7 @@ def _clone_parallel_agent(
     Returns:
         Cloned ParallelAgent preserving parallel execution semantics.
 
-    Note:
+    Notes:
         Structure preservation of ParallelAgent type ensures ADK Runner executes
         sub_agents concurrently rather than sequentially.
     """

--- a/src/gepa_adk/api.py
+++ b/src/gepa_adk/api.py
@@ -7,7 +7,7 @@ immediate feedback on invalid configurations. Each entry point has a dedicated
 pre-flight validator (_pre_flight_validate_evolve, _pre_flight_validate_group,
 _pre_flight_validate_workflow).
 
-Note:
+Notes:
     The public API exposes evolve(), evolve_group(), evolve_workflow(), and
     run_sync() as primary entry points.  All async functions should be
     awaited.  For synchronous usage in scripts, use run_sync(evolve(...))
@@ -137,7 +137,7 @@ def _resolve_model_for_agent(model_string: str) -> str | BaseLlm:
         # LiteLlm(model="ollama_chat/gpt-oss:20b")  — Wrapped
         ```
 
-    Note:
+    Notes:
         Selectively wraps models to preserve ADK's native Gemini optimizations
         while enabling full LiteLLM provider support for non-native models.
     """
@@ -185,7 +185,7 @@ def _apply_state_guard_validation(
     Returns:
         The validated component_text (may be modified if tokens were repaired/escaped).
 
-    Note:
+    Notes:
         Shared across evolve(), evolve_group(), and evolve_workflow()
         to ensure consistent StateGuard validation behavior.
     """
@@ -254,7 +254,7 @@ class SchemaBasedScorer:
         )
         ```
 
-    Note:
+    Notes:
         Adheres to Scorer protocol. Requires output_schema to have a "score"
         field. If score field is missing, raises MissingScoreFieldError.
     """
@@ -268,7 +268,7 @@ class SchemaBasedScorer:
         Raises:
             ConfigurationError: If output_schema doesn't have a "score" field.
 
-        Note:
+        Notes:
             Checks that the schema contains a "score" field during initialization.
         """
         self.output_schema = output_schema
@@ -319,7 +319,7 @@ class SchemaBasedScorer:
             # score == 0.9, metadata == {"result": "4"}
             ```
 
-        Note:
+        Notes:
             Operates synchronously by parsing JSON and extracting the score field.
             The expected parameter is ignored for schema-based scoring.
         """
@@ -397,7 +397,7 @@ class SchemaBasedScorer:
             # score == 0.9, metadata == {"result": "4"}
             ```
 
-        Note:
+        Notes:
             Operates by delegating to synchronous score() since JSON parsing
             does not require async I/O operations.
         """
@@ -429,7 +429,7 @@ def _resolve_evolution_services(
         Tuple of (session_service, artifact_service). artifact_service may be
         None if not provided by runner.
 
-    Note:
+    Notes:
         Service precedence follows this order:
         - If both runner and app are provided, a warning is logged and runner
           takes precedence (handled by caller via T009).
@@ -495,7 +495,7 @@ def _resolve_app_name(
         app_name = _resolve_app_name()  # Returns "gepa_executor"
         ```
 
-    Note:
+    Notes:
         Same precedence as _resolve_evolution_services is followed to ensure
         consistency between session_service and app_name resolution.
     """
@@ -521,7 +521,7 @@ def _validate_component_name(name: str, context: str) -> None:
     Raises:
         ConfigurationError: If the component name is invalid.
 
-    Note:
+    Notes:
         Safeguards component names for use as dictionary keys and in
         logging/debugging contexts.
     """
@@ -562,7 +562,7 @@ def _validate_dataset(
         ConfigurationError: If dataset is invalid (empty when not allowed,
             contains non-dict items, or items missing required keys).
 
-    Note:
+    Notes:
         Shared validation logic for trainset and valset to avoid duplication.
         Examples can contain 'input' (text), 'videos' (list of paths), or both.
     """
@@ -647,7 +647,7 @@ def _validate_evolve_inputs(
         ConfigurationError: If agent is not a valid LlmAgent instance or
             trainset is empty or missing required keys.
 
-    Note:
+    Notes:
         Safeguards that agent is an LlmAgent instance and trainset is
         non-empty with each example having an "input" key.
     """
@@ -679,7 +679,7 @@ def _validate_critic(critic: LlmAgent | None, agent: LlmAgent | None = None) -> 
         ConfigurationError: If critic is not a valid LlmAgent instance,
             or if no critic and agent lacks output_schema.
 
-    Note:
+    Notes:
         This is a pre-flight check. For evolve_group(), the output_schema
         check is handled by MultiAgentAdapter; only critic type is checked.
     """
@@ -715,7 +715,7 @@ def _validate_evolve_components(
         ConfigurationError: If the list contains empty strings, invalid
             identifiers, or duplicate names.
 
-    Note:
+    Notes:
         Validates each name via _validate_component_name() for identifier
         correctness, then checks list-level constraints (duplicates).
     """
@@ -755,7 +755,7 @@ def _pre_flight_validate_evolve(
     Raises:
         ConfigurationError: If any validation check fails.
 
-    Note:
+    Notes:
         Phase 1 (raw-input) checks run here. Phase 2 (post-resolution)
         checks like scorer wiring happen after dependency resolution
         in evolve() itself.
@@ -785,7 +785,7 @@ def _pre_flight_validate_group(
     Raises:
         ConfigurationError: If any validation check fails.
 
-    Note:
+    Notes:
         Agent names are validated as identifiers. Critic type is
         checked if provided. Dataset is validated. Per-agent component
         lists are checked for duplicates and empty strings.
@@ -820,7 +820,7 @@ def _pre_flight_validate_workflow(
     Raises:
         ConfigurationError: If any validation check fails.
 
-    Note:
+    Notes:
         Workflow agents are discovered from graph traversal, so agent
         type/name validation happens post-traversal in evolve_workflow().
     """
@@ -1018,7 +1018,7 @@ async def evolve_group(
         )
         ```
 
-    Note:
+    Notes:
         Breaking change in v0.3.x: The `agents` parameter changed from
         `list[LlmAgent]` to `dict[str, LlmAgent]`. Candidate keys now use
         qualified names (agent.component) instead of {agent_name}_instruction.
@@ -1208,7 +1208,7 @@ def _extract_evolved_components(
     Returns:
         Dictionary mapping qualified names (agent.component) to their evolved values.
 
-    Note:
+    Notes:
         Structured qualified names (agent.component format per ADR-012) are
         used as keys. Extracts evolved components from the engine result,
         falling back to seed values for components that weren't evolved.
@@ -1404,7 +1404,7 @@ async def evolve_workflow(
         )
         ```
 
-    Note:
+    Notes:
         Pre-flight validation runs synchronously before any LLM calls.
         Supports workflow agents (SequentialAgent, LoopAgent, ParallelAgent)
         with recursive traversal and depth limiting via max_depth parameter.
@@ -1594,7 +1594,7 @@ async def evolve(
             critic and output_schema, or EvolutionConfig consistency errors.
         EvolutionError: If evolution fails during execution.
 
-    Note:
+    Notes:
         Pre-flight validation runs synchronously before any LLM calls.
         Single-agent evolution with trainset reflection and valset scoring.
 
@@ -2030,7 +2030,7 @@ def run_sync(coro: Coroutine[Any, Any, _T]) -> _T:
         result = run_sync(evolve_group(agents, "primary", trainset=trainset))
         ```
 
-    Note:
+    Notes:
         In Jupyter notebooks or IPython, the event loop is already running.
         Use ``await evolve(...)`` directly instead of ``run_sync(evolve(...))``.
         The ``nest_asyncio`` fallback may work but ``await`` is preferred.
@@ -2157,7 +2157,7 @@ def evolve_sync(
         result = evolve_sync(agent, trainset, config=config)
         ```
 
-    Note:
+    Notes:
         Deprecated. Use ``run_sync(evolve(agent, trainset, ...))`` instead.
         ``run_sync`` is a universal wrapper that works with all async
         evolution functions.

--- a/src/gepa_adk/domain/__init__.py
+++ b/src/gepa_adk/domain/__init__.py
@@ -40,7 +40,7 @@ See Also:
     - [`gepa_adk.domain.types`][gepa_adk.domain.types]: Type aliases for domain concepts.
     - [`gepa_adk.domain.exceptions`][gepa_adk.domain.exceptions]: Exception hierarchy.
 
-Note:
+Notes:
     This package contains pure domain logic with no external dependencies.
     All models follow hexagonal architecture principles (ADR-000).
 """

--- a/src/gepa_adk/domain/exceptions.py
+++ b/src/gepa_adk/domain/exceptions.py
@@ -22,7 +22,7 @@ Examples:
     # Output: Field: max_iterations, Value: -1
     ```
 
-Note:
+Notes:
     The exception hierarchy provides structured error handling with
     contextual information for debugging and error recovery.
 
@@ -55,7 +55,7 @@ class EvolutionError(Exception):
         # Output: Caught: Evolution failed unexpectedly
         ```
 
-    Note:
+    Notes:
         Always use this base class or its subclasses for domain errors.
         Standard Python exceptions should still be raised for programming
         errors (e.g., TypeError, ValueError for developer mistakes).
@@ -91,7 +91,7 @@ class ConfigurationError(EvolutionError):
         # Output: max_iterations -5 >= 0
         ```
 
-    Note:
+    Notes:
         Arises from user-provided invalid settings, not programming errors.
         Should be caught and reported with clear guidance on valid values.
     """
@@ -112,9 +112,6 @@ class ConfigurationError(EvolutionError):
             value: The invalid value provided.
             constraint: Description of the validation constraint.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message)
         self.field = field
@@ -127,7 +124,7 @@ class ConfigurationError(EvolutionError):
         Returns:
             Formatted error message including field and value context.
 
-        Note:
+        Notes:
             Outputs formatted error message with field and value context
             when available, preserving base message structure.
         """
@@ -157,7 +154,7 @@ class NoCandidateAvailableError(EvolutionError):
         )
         ```
 
-    Note:
+    Notes:
         Arises when candidate selector cannot find any valid candidates
         from the Pareto frontier, typically due to empty frontier or
         filtering constraints.
@@ -175,14 +172,8 @@ class NoCandidateAvailableError(EvolutionError):
         Args:
             message: Human-readable error description.
             cause: Original exception that caused this error.
-
-        Other Parameters:
             **context: Arbitrary key-value pairs stored as exception attributes
                 for debugging context.
-
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message)
         self.cause = cause
@@ -194,7 +185,7 @@ class NoCandidateAvailableError(EvolutionError):
         Returns:
             Formatted error message including context and cause information.
 
-        Note:
+        Notes:
             Outputs formatted error message with context dict and cause chain
             when available, preserving base message structure.
         """
@@ -233,7 +224,7 @@ class EvaluationError(EvolutionError):
             ) from e
         ```
 
-    Note:
+    Notes:
         Always preserves the original cause for debugging while providing
         a consistent interface for error handling.
     """
@@ -250,12 +241,10 @@ class EvaluationError(EvolutionError):
         Args:
             message: Human-readable error description.
             cause: Original exception that caused this error.
-
-        Other Parameters:
             **context: Arbitrary key-value pairs stored as exception attributes
                 for debugging context.
 
-        Note:
+        Notes:
             Context is passed via keyword arguments. Positional arguments
             after message are not allowed.
         """
@@ -269,7 +258,7 @@ class EvaluationError(EvolutionError):
         Returns:
             Formatted message with context and cause information.
 
-        Note:
+        Notes:
             Outputs formatted error message with context dict and cause chain
             when available, preserving base message structure.
         """
@@ -303,7 +292,7 @@ class AdapterError(EvaluationError):
             )
         ```
 
-    Note:
+    Notes:
         AdapterError is a subclass of EvaluationError, so callers can
         catch either for different granularity of error handling.
     """
@@ -350,7 +339,7 @@ class RestoreError(AdapterError):
             )
         ```
 
-    Note:
+    Notes:
         As a subclass of AdapterError, this exception indicates that the
         agent state may be corrupted and manual intervention may be required
         to reset agents to a known state.
@@ -371,9 +360,6 @@ class RestoreError(AdapterError):
                 restoration. Must be non-empty when raising this exception.
             cause: Optional underlying cause exception.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message, cause=cause)
         self.errors = errors
@@ -384,7 +370,7 @@ class RestoreError(AdapterError):
         Returns:
             Formatted message including list of failed qualified names.
 
-        Note:
+        Notes:
             Outputs formatted error message with list of failed qualified
             names, preserving base message structure.
         """
@@ -414,7 +400,7 @@ class ScoringError(EvolutionError):
             print(f"Scoring failed: {e}")
         ```
 
-    Note:
+    Notes:
         All scoring exceptions inherit from this base class.
         ScoringError extends EvolutionError, following ADR-009 exception
         hierarchy guidelines.
@@ -432,9 +418,6 @@ class ScoringError(EvolutionError):
             message: Human-readable error description.
             cause: Original exception that caused this error.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message)
         self.cause = cause
@@ -445,7 +428,7 @@ class ScoringError(EvolutionError):
         Returns:
             Formatted message with cause information.
 
-        Note:
+        Notes:
             Outputs formatted error message with cause chain when available,
             preserving base message structure.
         """
@@ -478,7 +461,7 @@ class CriticOutputParseError(ScoringError):
             print(f"Error: {e.parse_error}")
         ```
 
-    Note:
+    Notes:
         Arises when critic agent output cannot be parsed as valid JSON.
         Typically occurs when LLM output doesn't follow structured format
         despite output_schema being set.
@@ -500,9 +483,6 @@ class CriticOutputParseError(ScoringError):
             parse_error: Description of the parsing failure.
             cause: Original exception that caused this error.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message, cause=cause)
         self.raw_output = raw_output
@@ -514,7 +494,7 @@ class CriticOutputParseError(ScoringError):
         Returns:
             Formatted message including parse error and raw output preview.
 
-        Note:
+        Notes:
             Outputs formatted error message with parse error and raw output
             preview (truncated to 100 chars), preserving base message structure.
         """
@@ -552,7 +532,7 @@ class OutputParseError(ScoringError):
             print(f"Error: {e.parse_error}")
         ```
 
-    Note:
+    Notes:
         Arises when agent output cannot be parsed as valid JSON.
         Typically occurs when LLM output doesn't follow structured format.
     """
@@ -573,9 +553,6 @@ class OutputParseError(ScoringError):
             parse_error: Description of the parsing failure.
             cause: Original exception that caused this error.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message, cause=cause)
         self.raw_output = raw_output
@@ -587,7 +564,7 @@ class OutputParseError(ScoringError):
         Returns:
             Formatted message including parse error and raw output preview.
 
-        Note:
+        Notes:
             Outputs formatted error message with parse error and raw output
             preview (truncated to 100 chars), preserving base message structure.
         """
@@ -630,7 +607,7 @@ class SchemaValidationError(ScoringError):
                 print(f"Error at line {e.line_number}")
         ```
 
-    Note:
+    Notes:
         Arises when output is valid JSON but doesn't match the schema.
         Typically occurs when field types are wrong or required fields
         have invalid values. For schema evolution, also raised when
@@ -661,9 +638,6 @@ class SchemaValidationError(ScoringError):
                 - "structure": Missing BaseModel, has imports/functions
                 - "execution": Error during exec()
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message, cause=cause)
         self.raw_output = raw_output
@@ -677,7 +651,7 @@ class SchemaValidationError(ScoringError):
         Returns:
             Formatted message including validation error details.
 
-        Note:
+        Notes:
             Outputs formatted error message with validation error and raw output
             preview (truncated to 100 chars), preserving base message structure.
         """
@@ -718,7 +692,7 @@ class MissingScoreFieldError(ScoringError):
             print(f"Missing score. Available fields: {e.available_fields}")
         ```
 
-    Note:
+    Notes:
         Applies when parsed output lacks a valid score value.
         The parsed_output may contain other valid fields that will be
         preserved in metadata if score is found.
@@ -738,9 +712,6 @@ class MissingScoreFieldError(ScoringError):
             parsed_output: The parsed dict without valid score field.
             cause: Original exception that caused this error.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message, cause=cause)
         self.parsed_output = parsed_output
@@ -752,7 +723,7 @@ class MissingScoreFieldError(ScoringError):
         Returns:
             Formatted message including list of available fields.
 
-        Note:
+        Notes:
             Outputs formatted error message with list of available fields
             from parsed output, preserving base message structure.
         """
@@ -796,7 +767,7 @@ class VideoValidationError(ConfigurationError):
             print(f"Constraint violated: {e.constraint}")
         ```
 
-    Note:
+    Notes:
         Arises from video file validation failures during multimodal input
         processing. File existence, size limits (2GB), and MIME type
         (video/*) are validated before loading video content.
@@ -818,9 +789,6 @@ class VideoValidationError(ConfigurationError):
             field: Name of the configuration field (default "video").
             constraint: Description of the validation constraint violated.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message, field=field, value=video_path, constraint=constraint)
         self.video_path = video_path
@@ -831,7 +799,7 @@ class VideoValidationError(ConfigurationError):
         Returns:
             Formatted error message including video_path and constraint.
 
-        Note:
+        Notes:
             Outputs formatted error message with video_path for easy
             identification of the problematic file in error logs.
         """
@@ -869,7 +837,7 @@ class MultiAgentValidationError(EvolutionError):
         print(error.field, error.value)  # agents []
         ```
 
-    Note:
+    Notes:
         Arises from user-provided invalid multi-agent settings, not
         programming errors. Should be caught and reported with clear
         guidance on valid values.
@@ -891,9 +859,6 @@ class MultiAgentValidationError(EvolutionError):
             value: The invalid value provided.
             constraint: Description of the validation constraint.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message)
         self.field = field
@@ -906,7 +871,7 @@ class MultiAgentValidationError(EvolutionError):
         Returns:
             Formatted error message including field and value context.
 
-        Note:
+        Notes:
             Outputs formatted error message with field, value, and constraint
             context when available, preserving base message structure.
         """
@@ -939,7 +904,7 @@ class WorkflowEvolutionError(EvolutionError):
             print(f"Workflow '{e.workflow_name}' failed: {e}")
         ```
 
-    Note:
+    Notes:
         Arises when workflow contains no LlmAgents or evolution fails
         during execution. Follows ADR-009 exception hierarchy.
     """
@@ -958,9 +923,6 @@ class WorkflowEvolutionError(EvolutionError):
             workflow_name: Name of the workflow that failed.
             cause: Original exception that caused this error.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message)
         self.workflow_name = workflow_name
@@ -972,7 +934,7 @@ class WorkflowEvolutionError(EvolutionError):
         Returns:
             Formatted message with workflow name and cause information.
 
-        Note:
+        Notes:
             Outputs formatted error message including workflow context when
             available. Preserves cause chain for debugging nested exceptions.
         """
@@ -1007,7 +969,7 @@ class ConfigValidationError(EvolutionError):
         print(error.errors)  # ["temperature must be 0.0-2.0, got 3.0"]
         ```
 
-    Note:
+    Notes:
         Arises when proposed config values violate parameter constraints
         or when YAML parsing fails. Should be caught and logged as a warning,
         with the original config preserved.
@@ -1025,9 +987,6 @@ class ConfigValidationError(EvolutionError):
             message: Human-readable error description.
             errors: List of individual validation errors.
 
-        Note:
-            Context fields use keyword-only syntax to ensure explicit labeling
-            and prevent positional argument mistakes.
         """
         super().__init__(message)
         self.errors = errors or []
@@ -1038,7 +997,7 @@ class ConfigValidationError(EvolutionError):
         Returns:
             Formatted error message including list of validation errors.
 
-        Note:
+        Notes:
             Outputs formatted error message with validation errors list
             when available, preserving base message structure.
         """
@@ -1072,7 +1031,7 @@ class InvalidScoreListError(ScoringError):
             print(f"Invalid scores: {e.reason}, scores: {e.scores}")
         ```
 
-    Note:
+    Notes:
         Arises when evaluation batch scores cannot be aggregated for acceptance.
         Empty batches or non-finite values would corrupt evolution decisions.
     """
@@ -1093,7 +1052,7 @@ class InvalidScoreListError(ScoringError):
             reason: Why the scores are invalid ("empty" or "non-finite").
             cause: Original exception that caused this error.
 
-        Note:
+        Notes:
             Context fields use keyword-only syntax to ensure explicit labeling.
         """
         super().__init__(message, cause=cause)
@@ -1106,7 +1065,7 @@ class InvalidScoreListError(ScoringError):
         Returns:
             Formatted message including reason and score list preview.
 
-        Note:
+        Notes:
             Outputs formatted error message with reason and score list preview
             (first 5 scores), preserving base message structure.
         """

--- a/src/gepa_adk/domain/models.py
+++ b/src/gepa_adk/domain/models.py
@@ -71,7 +71,7 @@ See Also:
     - [`gepa_adk.ports.evolution_result`][gepa_adk.ports.evolution_result]:
       Protocol that EvolutionResult and MultiAgentEvolutionResult satisfy.
 
-Note:
+Notes:
     These models are pure data containers with validation logic. They have
     no knowledge of infrastructure concerns like databases or APIs.
 """
@@ -147,7 +147,7 @@ class VideoFileInfo:
         print(f"File: {info.path}, Size: {info.size_bytes}, Type: {info.mime_type}")
         ```
 
-    Note:
+    Notes:
         A frozen dataclass ensuring immutability after validation.
         Instances cannot be modified once created, guaranteeing
         consistency of validated file metadata.
@@ -211,7 +211,7 @@ class EvolutionConfig:
         print(config.reflection_model)  # ollama_chat/gpt-oss:20b
         ```
 
-    Note:
+    Notes:
         All numeric parameters are validated in __post_init__ to ensure
         they meet their constraints. Cross-field consistency is also checked
         (e.g., use_merge requires max_merge_invocations > 0, stop_callbacks
@@ -244,7 +244,7 @@ class EvolutionConfig:
                 rules (e.g., use_merge requires max_merge_invocations > 0,
                 stop_callbacks must be callable).
 
-        Note:
+        Notes:
             Operates automatically after dataclass __init__ completes. Validates
             all fields including finite-float checks, cross-field consistency,
             and raises ConfigurationError with context on failure.
@@ -337,7 +337,7 @@ class EvolutionConfig:
             ConfigurationError: If use_merge is True but max_merge_invocations
                 is zero, or if stop_callbacks contains non-callable items.
 
-        Note:
+        Notes:
             Hard errors raise ConfigurationError; soft issues log warnings.
             Called from __post_init__ after individual field validation.
         """
@@ -376,7 +376,7 @@ class EvolutionConfig:
         Converts empty string to None with info log. Warns if required
         placeholders are missing but allows the config to be created.
 
-        Note:
+        Notes:
             Soft validation approach - missing placeholders trigger warnings
             but don't prevent config creation for maximum flexibility.
         """
@@ -464,7 +464,7 @@ class IterationRecord:
         assert restored.score == record.score
         ```
 
-    Note:
+    Notes:
         An immutable record that captures iteration metrics. Once created,
         IterationRecord instances cannot be modified, ensuring historical
         accuracy of the evolution trace.
@@ -647,7 +647,7 @@ class EvolutionResult:
         restored = EvolutionResult.from_dict(json.loads(json_str))
         ```
 
-    Note:
+    Notes:
         As a frozen dataclass, EvolutionResult instances cannot be modified.
     """
 
@@ -765,7 +765,7 @@ class EvolutionResult:
             The difference between final_score and original_score.
             Positive values indicate improvement, negative indicates degradation.
 
-        Note:
+        Notes:
             Override is not needed since frozen dataclasses support properties.
         """
         return self.final_score - self.original_score
@@ -777,7 +777,7 @@ class EvolutionResult:
         Returns:
             True if final_score > original_score, False otherwise.
 
-        Note:
+        Notes:
             Only returns True for strict improvement, not equal scores.
         """
         return self.final_score > self.original_score
@@ -947,7 +947,7 @@ class Candidate:
         print(candidate.generation)  # 0
         ```
 
-    Note:
+    Notes:
         A mutable candidate representation with richer state tracking than
         GEPA's simple dict. Components and metadata can be modified during
         the evolution process. Use generation and parent_id to track lineage.
@@ -1018,7 +1018,7 @@ class MultiAgentEvolutionResult:
         restored = MultiAgentEvolutionResult.from_dict(json.loads(json.dumps(d)))
         ```
 
-    Note:
+    Notes:
         An immutable result container for multi-agent evolution. Once created,
         MultiAgentEvolutionResult instances cannot be modified. Use computed
         properties like `improvement`, `improved`, and `agent_names` to analyze
@@ -1118,7 +1118,7 @@ class MultiAgentEvolutionResult:
             The difference between final_score and original_score.
             Positive values indicate improvement, negative indicates degradation.
 
-        Note:
+        Notes:
             Override is not needed since frozen dataclasses support properties.
         """
         return self.final_score - self.original_score
@@ -1130,7 +1130,7 @@ class MultiAgentEvolutionResult:
         Returns:
             True if final_score > original_score, False otherwise.
 
-        Note:
+        Notes:
             Only returns True for strict improvement, not equal scores.
         """
         return self.final_score > self.original_score
@@ -1142,7 +1142,7 @@ class MultiAgentEvolutionResult:
         Returns:
             Sorted list of agent names from evolved_components keys.
 
-        Note:
+        Notes:
             Outputs a new list each time, sorted alphabetically for
             consistent ordering regardless of insertion order.
         """

--- a/src/gepa_adk/domain/state.py
+++ b/src/gepa_adk/domain/state.py
@@ -15,7 +15,7 @@ Examples:
     print(state.get_average_score(idx))  # 0.8
     ```
 
-Note:
+Notes:
     This module captures Pareto frontier leaders and candidate state.
 
 See Also:
@@ -39,7 +39,7 @@ from gepa_adk.domain.types import FrontierKey, FrontierType, Score
 class FrontierLogger(Protocol):
     """Protocol for logging frontier update events.
 
-    Note:
+    Notes:
         A lightweight logger interface keeps frontier updates consistent.
 
     Examples:
@@ -59,8 +59,6 @@ class FrontierLogger(Protocol):
 
         Args:
             event: Event name identifier.
-
-        Other Parameters:
             **kwargs: Structured metadata for the event.
 
         Examples:
@@ -94,7 +92,7 @@ class ParetoFrontier:
         frontier.update(0, {0: 0.8, 1: 0.6})
         ```
 
-    Note:
+    Notes:
         A frontier stores the best candidate indices per dimension for sampling.
         The active dimension depends on frontier_type.
     """
@@ -120,8 +118,8 @@ class ParetoFrontier:
             scores: Mapping of example index to score.
             logger: Optional structured logger for leader updates.
 
-        Note:
-            Outputs updated leader sets and best scores for instance-level
+        Notes:
+            Mutates ``example_leaders`` and ``best_scores`` for instance-level
             frontier tracking.
 
         Examples:
@@ -162,7 +160,7 @@ class ParetoFrontier:
             Set of candidate indices that are non-dominated (lead at
             least one example).
 
-        Note:
+        Notes:
             Outputs the union of all leader sets across example indices.
         """
         candidates: set[int] = set()
@@ -177,7 +175,7 @@ class ParetoFrontier:
             Mapping of candidate index to leadership count, usable as
             weights for weighted sampling.
 
-        Note:
+        Notes:
             Outputs weights proportional to how many examples each candidate
             leads, enabling weighted sampling.
         """
@@ -201,8 +199,8 @@ class ParetoFrontier:
             objective_scores: Mapping of objective name to score.
             logger: Optional structured logger for leader updates.
 
-        Note:
-            Outputs updated objective leader sets and best scores for
+        Notes:
+            Mutates ``objective_leaders`` and ``objective_best_scores`` for
             objective-level frontier tracking.
 
         Examples:
@@ -252,8 +250,8 @@ class ParetoFrontier:
             objective_scores: Mapping of example index to objective scores dict.
             logger: Optional structured logger for leader updates.
 
-        Note:
-            Outputs updated cartesian leader sets and best scores for
+        Notes:
+            Mutates ``cartesian_leaders`` and ``cartesian_best_scores`` for
             per (example, objective) pair frontier tracking.
 
         Examples:
@@ -308,7 +306,7 @@ class ParetoFrontier:
         Raises:
             ValueError: If frontier_type is not a supported value.
 
-        Note:
+        Notes:
             Outputs a mapping with keys appropriate for the frontier type
             (int for INSTANCE, str for OBJECTIVE, tuples for HYBRID/CARTESIAN).
 
@@ -369,7 +367,7 @@ class ParetoState:
         state.add_candidate(Candidate(components={"instruction": "seed"}), [0.5])
         ```
 
-    Note:
+    Notes:
         A single state object keeps frontier and candidate metrics aligned.
     """
 
@@ -392,7 +390,7 @@ class ParetoState:
             ConfigurationError: If any candidate_scores index exceeds the
                 candidates list length.
 
-        Note:
+        Notes:
             Checks candidate_scores indices are valid and marks frontier_type
             as initialized for immutability enforcement.
         """
@@ -416,7 +414,7 @@ class ParetoState:
             ConfigurationError: If frontier_type is changed after
                 ParetoState initialization.
 
-        Note:
+        Notes:
             Only frontier_type is protected because it determines the frontier
             update routing logic in add_candidate(). Other fields (candidates,
             frontier, candidate_scores) are intentionally mutable to support
@@ -496,7 +494,7 @@ class ParetoState:
         Raises:
             ConfigurationError: If objective_scores are required but not provided.
 
-        Note:
+        Notes:
             Outputs the new candidate index after routing to the appropriate
             frontier update method based on frontier_type.
 
@@ -603,7 +601,7 @@ class ParetoState:
         Raises:
             NoCandidateAvailableError: If candidate scores are missing.
 
-        Note:
+        Notes:
             Outputs the arithmetic mean of all scores for the candidate
             across evaluated examples.
 
@@ -623,7 +621,7 @@ class ParetoState:
     def update_best_average(self) -> None:
         """Update best_average_idx based on current scores.
 
-        Note:
+        Notes:
             Outputs the candidate index with the highest mean score, or None
             if no candidates have scores.
         """

--- a/src/gepa_adk/domain/stopper.py
+++ b/src/gepa_adk/domain/stopper.py
@@ -22,7 +22,7 @@ Examples:
     )
     ```
 
-Note:
+Notes:
     This StopperState snapshot is intentionally minimal. Add fields as needed
     for specific stopper implementations. The frozen dataclass ensures stoppers
     cannot accidentally mutate evolution state.
@@ -74,7 +74,7 @@ class StopperState:
         state.iteration = 11  # Raises FrozenInstanceError
         ```
 
-    Note:
+    Notes:
         A frozen dataclass, all fields are immutable after creation.
         Using slots=True for memory efficiency.
     """

--- a/src/gepa_adk/domain/trajectory.py
+++ b/src/gepa_adk/domain/trajectory.py
@@ -18,7 +18,7 @@ Examples:
     )
     ```
 
-Note:
+Notes:
     These types are immutable (frozen dataclasses) to ensure trajectory data
     cannot be modified after capture, maintaining audit integrity.
 
@@ -113,7 +113,7 @@ class ADKTrajectory:
         )
         ```
 
-    Note:
+    Notes:
         All fields use immutable types (tuples, not lists) to prevent
         accidental modification of captured trace data.
     """
@@ -158,7 +158,7 @@ class MultiAgentTrajectory:
         )
         ```
 
-    Note:
+    Notes:
         All fields use immutable types to prevent accidental modification
         of captured trace data. agent_trajectories maps agent names to
         their individual ADKTrajectory records.

--- a/src/gepa_adk/domain/types.py
+++ b/src/gepa_adk/domain/types.py
@@ -46,7 +46,7 @@ See Also:
     - [`gepa_adk.ports.adapter`][gepa_adk.ports.adapter]:
       Protocol that references Score and ComponentName.
 
-Note:
+Notes:
     Type aliases are lightweight hints that improve code readability
     and IDE support. They do not enforce validation at runtime.
     Configuration types use frozen dataclasses for immutability.
@@ -106,7 +106,7 @@ Examples:
     name = spec.qualified  # Returns QualifiedComponentName
     ```
 
-Note:
+Notes:
     At runtime, QualifiedComponentName is just a str. The NewType wrapper
     only affects static type checking, not runtime behavior.
 """
@@ -145,7 +145,7 @@ Examples:
     }
     ```
 
-Note:
+Notes:
     All agent names must exist in the agents dict.
     All component names must have registered handlers.
     Empty list excludes the agent from evolution.
@@ -176,7 +176,7 @@ class TrajectoryConfig:
     whether sensitive data should be redacted, and whether large
     values should be truncated.
 
-    Note:
+    Notes:
         All configuration fields are immutable after instantiation,
         ensuring consistent extraction behavior throughout evolution.
 
@@ -229,7 +229,7 @@ class TrajectoryConfig:
         config = TrajectoryConfig(max_string_length=None)
         ```
 
-    Note:
+    Notes:
         Redaction takes precedence over truncation. Sensitive values are
         replaced with "[REDACTED]" first, then truncation applies to the
         remaining (non-sensitive) strings.
@@ -282,7 +282,7 @@ class ComponentSpec:
         candidate.components[spec.qualified] = "evolved instruction..."
         ```
 
-    Note:
+    Notes:
         An immutable (frozen) dataclass that provides type-safe qualified name
         construction. The qualified property returns a QualifiedComponentName
         (NewType) for type safety with handlers.
@@ -304,7 +304,7 @@ class ComponentSpec:
             name = spec.qualified  # QualifiedComponentName("gen.instruction")
             ```
 
-        Note:
+        Notes:
             Output format follows ADR-012 dot-separated convention.
         """
         return QualifiedComponentName(f"{self.agent}.{self.component}")
@@ -330,7 +330,7 @@ class ComponentSpec:
             assert spec.component == "output_schema"
             ```
 
-        Note:
+        Notes:
             Only the first dot is used as separator, allowing component names
             with dots (though this is not recommended).
         """
@@ -356,7 +356,7 @@ class ComponentSpec:
 class FrontierType(str, Enum):
     """Supported frontier tracking strategies for Pareto selection.
 
-    Note:
+    Notes:
         All four frontier types enable different Pareto dominance tracking
         strategies for multi-objective optimization.
 
@@ -428,7 +428,7 @@ Examples:
     }
     ```
 
-Note:
+Notes:
     This type alias is compatible with GEPA's `Candidate` type
     (dict[str, str]), enabling seamless integration with existing
     mutation proposers and evolution engine components.
@@ -493,7 +493,7 @@ Examples:
     failed: MergeAttempt = None
     ```
 
-Note:
+Notes:
     Type alias reserved for future merge reporting; currently unused but kept for
     parity with the merge-proposer design docs.
 """
@@ -514,7 +514,7 @@ Examples:
     log: AncestorLog = (5, 8, 2)  # (parent1_idx, parent2_idx, ancestor_idx)
     ```
 
-Note:
+Notes:
     Type alias used by MergeProposer to track which merge combinations have already been attempted,
     preventing redundant merge operations.
 """
@@ -558,7 +558,7 @@ class SchemaConstraints:
         )
         ```
 
-    Note:
+    Notes:
         A frozen dataclass ensures immutability during evolution runs.
         Configuration is validated at evolution start.
     """
@@ -602,7 +602,7 @@ class ProposalResult:
         )
         ```
 
-    Note:
+    Notes:
         A frozen dataclass ensures immutability of proposal results.
         Parent indices must be valid indices into the ParetoState.candidates list.
     """
@@ -667,7 +667,7 @@ Examples:
     )
     ```
 
-Note:
+Notes:
     This replaces the previous workaround of embedding data in user
     messages via Python f-strings.
 """

--- a/src/gepa_adk/engine/adk_reflection.py
+++ b/src/gepa_adk/engine/adk_reflection.py
@@ -122,7 +122,7 @@ def create_adk_reflection_fn(
         - [`gepa_adk.api.evolve`][gepa_adk.api.evolve]: Standard wiring pattern
           for constructing the reflection chain.
 
-    Note:
+    Notes:
         Opens a fresh ADK session for each invocation via AgentExecutor, ensuring
         complete isolation between reflection operations. State is initialized with
         component_text (str) and trials (JSON-serialized list of trial records).
@@ -170,7 +170,7 @@ def create_adk_reflection_fn(
             RuntimeError: If ADK agent execution fails. The exception is logged
                 and re-raised for upstream handling.
 
-        Note:
+        Notes:
             Opens a unique session with fresh state for each invocation via
             AgentExecutor, ensuring isolation between reflection operations.
         """

--- a/src/gepa_adk/engine/async_engine.py
+++ b/src/gepa_adk/engine/async_engine.py
@@ -37,7 +37,7 @@ See Also:
     - [`gepa_adk.domain.state`][gepa_adk.domain.state]: ParetoState for
       multi-objective candidate tracking.
 
-Note:
+Notes:
     Tracks separate trainset and valset evaluation flows for evolution.
     Supports optional Pareto-based candidate selection, component-level
     mutation, evaluation policies, merge proposals, custom stoppers,
@@ -125,7 +125,7 @@ class _EngineState:
         )
         ```
 
-    Note:
+    Notes:
         Aggregates reflection metadata needed to drive proposal generation.
         Tracks acceptance score (sum/mean) separately from valset mean.
     """
@@ -178,7 +178,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         print(f"Final score: {result.final_score}")
         ```
 
-    Note:
+    Notes:
         Avoid reusing engine instances after run() completes.
         When a seeded ``rng`` is provided, it is used for the auto-created
         merge proposer. The API layer passes the same ``rng`` to candidate
@@ -240,7 +240,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             )
             ```
 
-        Note:
+        Notes:
             Configures trainset and valset routing for reflection and scoring.
             Initializes stopper lifecycle tracking for custom stop callbacks.
         """
@@ -304,7 +304,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             InvalidScoreListError: If scores list is empty or contains
                 non-finite values.
 
-        Note:
+        Notes:
             Sums or averages acceptance scores after validating they are
             non-empty and finite. Uses sum or mean based on config.acceptance_metric.
         """
@@ -336,7 +336,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Returns:
             List of stoppers that had setup() called (for cleanup in reverse order).
 
-        Note:
+        Notes:
             Only invokes setup() on stoppers implementing the lifecycle method.
             Stoppers that fail setup() are excluded from stop_callbacks for the
             remainder of execution to prevent inconsistent state.
@@ -371,9 +371,9 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Args:
             setup_stoppers: List of stoppers that had setup() called.
 
-        Note:
-            Observes reverse-order cleanup contract (T025).
-            If cleanup() raises, logs error and continues (T026).
+        Notes:
+            Follows the reverse-order cleanup contract (T025).
+            When cleanup() raises, logs the error and continues (T026).
         """
         for stopper in reversed(setup_stoppers):
             cleanup_method = getattr(stopper, "cleanup", None)
@@ -398,7 +398,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             stagnation counter, total evaluations, candidates count, and
             elapsed time.
 
-        Note:
+        Notes:
             Obtains elapsed_seconds from monotonic time since run() started.
             Uses zero if _start_time has not yet been set.
         """
@@ -435,7 +435,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Returns:
             List of component keys to consider for update.
 
-        Note:
+        Notes:
             Selects component keys, filtering out the default component name when
             more specific per-agent component keys are present.
         """
@@ -454,7 +454,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         on valset for scoring. Caches the reflection batch for use in
         the first mutation proposal.
 
-        Note:
+        Notes:
             Sets up both reflection and scoring baselines up front.
         """
         # Create pareto_state before evaluation if candidate_selector exists
@@ -555,7 +555,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Returns:
             Tuple of (mean score across trainset examples, evaluation batch).
 
-        Note:
+        Notes:
             Supplies trajectories for reflective dataset construction.
         """
         eval_batch = await self.adapter.evaluate(
@@ -580,7 +580,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             Score is aggregated using acceptance_metric (sum or mean).
             eval_indices are the valset indices that were actually evaluated.
 
-        Note:
+        Notes:
             Supplies scores without traces for acceptance decisions.
             Aggregation method (sum/mean) is determined by config.acceptance_metric.
             Uses evaluation_policy to determine which examples to evaluate.
@@ -623,7 +623,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             Tuple of (new candidate with proposed component updates,
             list of component names that were updated).
 
-        Note:
+        Notes:
             Spawns a new candidate with updated components based on reflective
             dataset analysis and component selector strategy.
         """
@@ -732,9 +732,9 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
                 the reflection agent explaining the mutation. None when
                 reasoning is not available.
 
-        Note:
-            Stores an IterationRecord in the engine state's iteration_history,
-            preserving chronological evolution trace for analysis.
+        Notes:
+            Appends an IterationRecord to ``state.iteration_history`` so the
+            chronological evolution trace is preserved for analysis.
         """
         assert self._state is not None, "Engine state not initialized"
         record = IterationRecord(
@@ -756,7 +756,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             evolution should continue. Conditions are checked in priority
             order: max iterations, early stopping patience, custom stoppers.
 
-        Note:
+        Notes:
             Only active stoppers (those that passed setup or have no setup
             method) are invoked. Patience-based early stopping maps to
             ``MAX_ITERATIONS`` because it is a built-in convergence
@@ -808,7 +808,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Returns:
             True if proposal_score > best_score + min_improvement_threshold.
 
-        Note:
+        Notes:
             Signals True when proposal exceeds best score by the configured
             improvement threshold, enabling configurable acceptance sensitivity.
         """
@@ -830,7 +830,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             True if valid or no output_schema component present.
             False if output_schema validation fails.
 
-        Note:
+        Notes:
             This validation runs before expensive evaluation to reject
             invalid schemas early. Security checks (no imports, no functions)
             are enforced to prevent code injection.
@@ -887,9 +887,9 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             objective_scores: Optional objective scores from scoring batch.
                 None when adapter does not provide objective scores.
 
-        Note:
-            Swaps cached reflection batch for next proposal iteration.
-            Tracks acceptance score and valset mean separately.
+        Notes:
+            Replaces the cached reflection batch for the next proposal
+            iteration and tracks acceptance score and valset mean separately.
         """
         assert self._state is not None, "Engine state not initialized"
         # Create new candidate with lineage
@@ -921,7 +921,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Returns:
             Frozen EvolutionResult with all metrics and original_components.
 
-        Note:
+        Notes:
             Synthesizes a frozen EvolutionResult containing all evolution metrics,
             history, and original_components snapshot, suitable for immutable
             result reporting. The evolved_components dict contains all component
@@ -978,7 +978,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
             print(f"Best score: {result.final_score}")
             ```
 
-        Note:
+        Notes:
             Outputs a frozen EvolutionResult after completing the evolution
             loop. Engine instance should not be reused after run() completes.
             Method is idempotent if called multiple times (restarts fresh).
@@ -1028,7 +1028,7 @@ class AsyncGEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         Returns:
             EvolutionResult with evolution outcomes.
 
-        Note:
+        Notes:
             Only called from run(). Handles the evolution loop body
             while run() manages stopper lifecycle. The loop tracks
             ``StopReason`` to report why evolution terminated.

--- a/src/gepa_adk/engine/genealogy.py
+++ b/src/gepa_adk/engine/genealogy.py
@@ -35,7 +35,7 @@ See Also:
     - [`Candidate`][gepa_adk.domain.models.Candidate]: Domain model whose
       lineage is tracked by these functions.
 
-Note:
+Notes:
     This module provides genealogy tracking functions for merge operations.
     Genealogy tracking enables merge operations by identifying which candidates
     share common ancestry and can be safely combined.
@@ -83,7 +83,7 @@ def get_ancestors(
         # Returns: {0, 1, 2}
         ```
 
-    Note:
+    Notes:
         Operations use BFS to avoid recursion depth issues with deep genealogies.
         Prevents cycles by tracking visited nodes.
     """
@@ -152,7 +152,7 @@ def find_common_ancestor(
         # Returns: None (separate lineages)
         ```
 
-    Note:
+    Notes:
         Operations return the highest-indexed common ancestor to ensure we find the most
         recent shared ancestor, which is most useful for merge operations.
     """
@@ -251,7 +251,7 @@ def filter_ancestors_by_score(
         # Returns: {1, 2} (0 filtered out)
         ```
 
-    Note:
+    Notes:
         Operations exclude ancestors without scores from the result.
     """
     from statistics import fmean
@@ -301,7 +301,7 @@ def detect_component_divergence(
         # Returns: {"output_schema"}
         ```
 
-    Note:
+    Notes:
         Only checks components present in the ancestor. Components added by
         the parent are ignored. Missing components are not considered diverged.
     """
@@ -359,7 +359,7 @@ def has_desirable_predictors(
         assert has_desirable_predictors(ancestor, parent1, parent2) is False
         ```
 
-    Note:
+    Notes:
         Operations return False if no components have changed, or if both parents
         changed the same components identically.
     """

--- a/src/gepa_adk/engine/merge_proposer.py
+++ b/src/gepa_adk/engine/merge_proposer.py
@@ -26,7 +26,7 @@ See Also:
     - [`ParetoState`][gepa_adk.domain.state.ParetoState]: Evolution state
       consumed by the propose method.
 
-Note:
+Notes:
     This module provides genetic crossover capabilities for evolution.
     MergeProposer implements ProposerProtocol and can be used alongside
     mutation proposers in the evolution engine.
@@ -72,7 +72,7 @@ class MergeProposer:
         if result:
             print(f"Merged from parents {result.parent_indices}")
         ```
-    Note:
+    Notes:
         A proposer that combines two Pareto-optimal candidates via genetic crossover.
         Selects candidates from the frontier that share a common ancestor and merges
         their complementary component improvements.
@@ -91,10 +91,9 @@ class MergeProposer:
             val_overlap_floor: Minimum overlapping validation examples required.
             max_attempts: Maximum merge attempts before giving up.
 
-        Note:
-            Creates a new MergeProposer instance with the specified random number
-            generator and configuration parameters. The attempted_merges set is
-            initialized empty to track merge attempts.
+        Notes:
+            The ``attempted_merges`` set starts empty so previously tried
+            parent pairs can be skipped on subsequent calls.
         """
         self.rng = rng
         self.val_overlap_floor = val_overlap_floor
@@ -131,7 +130,7 @@ class MergeProposer:
                 print(f"Ancestor: {result.metadata['ancestor_idx']}")
             ```
 
-        Note:
+        Notes:
             Operations select candidates from Pareto frontier only. Requires common ancestor
             and complementary component changes for successful merge. Validates
             minimum validation overlap before merging.
@@ -225,7 +224,7 @@ class MergeProposer:
             Tuple of (parent1_idx, parent2_idx, ancestor_idx) or None if no
             suitable pair found.
 
-        Note:
+        Notes:
             Searches for suitable merge candidates from the Pareto frontier.
             Requires common ancestor and prevents duplicate merge attempts.
         """
@@ -319,7 +318,7 @@ class MergeProposer:
         Returns:
             Merged component dictionary.
 
-        Note:
+        Notes:
             Strategy for merging components:
             - If both parents same → take either
             - If one unchanged from ancestor, other changed → take changed value

--- a/src/gepa_adk/engine/proposer.py
+++ b/src/gepa_adk/engine/proposer.py
@@ -49,7 +49,7 @@ See Also:
     - [`gepa_adk.engine.adk_reflection`][gepa_adk.engine.adk_reflection]: ADK-based
       reflection function factory.
 
-Note:
+Notes:
     This module requires an ADK reflection function for proposing mutations.
     Use `create_adk_reflection_fn()` from `gepa_adk.engine.adk_reflection` to
     create a reflection function from an ADK LlmAgent.
@@ -122,7 +122,7 @@ class AsyncReflectiveMutationProposer:
         )
         ```
 
-    Note:
+    Notes:
         ADK-based reflection via `adk_reflection_fn` is the only supported
         approach. Use `create_adk_reflection_fn()` from
         `gepa_adk.engine.adk_reflection` to create the reflection function.
@@ -152,7 +152,7 @@ class AsyncReflectiveMutationProposer:
             proposer = AsyncReflectiveMutationProposer(adk_reflection_fn=reflection_fn)
             ```
 
-        Note:
+        Notes:
             Configuration validation happens immediately to fail fast rather
             than waiting until the first propose() call. After each
             ``propose()`` call, ``self.last_reasoning`` holds the most
@@ -225,7 +225,7 @@ class AsyncReflectiveMutationProposer:
             # result: {"instruction": "Greet users formally..."}
             ```
 
-        Note:
+        Notes:
             Calls the reflection function directly with
             ``(component_text, trials, component_name)``. The function
             returns ``(proposed_text, reasoning)``; reasoning is stored

--- a/src/gepa_adk/ports/__init__.py
+++ b/src/gepa_adk/ports/__init__.py
@@ -79,7 +79,7 @@ See Also:
     - [`gepa_adk.ports.evolution_result`][gepa_adk.ports.evolution_result]: Evolution result
         protocol for unified result type handling.
 
-Note:
+Notes:
     This layer follows hexagonal architecture principles, defining
     ports that adapters implement to integrate with external systems.
 """

--- a/src/gepa_adk/ports/adapter.py
+++ b/src/gepa_adk/ports/adapter.py
@@ -28,7 +28,7 @@ See Also:
     - [`gepa_adk.domain.models`][gepa_adk.domain.models]: Domain models used
         alongside adapter results.
 
-Note:
+Notes:
     This module defines the core protocol interface that connects
     gepa-adk's evolution engine to external evaluation systems.
 """
@@ -86,7 +86,7 @@ class EvaluationBatch(Generic[Trajectory, RolloutOutput]):
         )
         ```
 
-    Note:
+    Notes:
         All fields are immutable once created due to frozen=True.
         Use this as the standard return type from adapter evaluations.
         When metadata is not None, len(metadata) must equal len(outputs) and len(scores).
@@ -129,7 +129,7 @@ class AsyncGEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
                 }
         ```
 
-    Note:
+    Notes:
         Adapters must implement all three async methods to satisfy
         the protocol. Use runtime_checkable for isinstance() checks.
     """
@@ -158,7 +158,7 @@ class AsyncGEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
             assert len(result.scores) == len(batch)
             ```
 
-        Note:
+        Notes:
             Output and score lists must have the same length as the
             input batch. Set capture_traces=True to enable reflection.
         """
@@ -190,7 +190,7 @@ class AsyncGEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
             )
             ```
 
-        Note:
+        Notes:
             Only call this method when eval_batch contains trajectories.
             Each component receives its own list of reflective examples.
         """
@@ -222,7 +222,7 @@ class AsyncGEPAAdapter(Protocol[DataInst, Trajectory, RolloutOutput]):
             )
             ```
 
-        Note:
+        Notes:
             Outputs should contain improved text for each requested
             component. The evolution engine uses these as mutation candidates.
         """

--- a/src/gepa_adk/ports/agent_executor.py
+++ b/src/gepa_adk/ports/agent_executor.py
@@ -33,7 +33,7 @@ See Also:
     - [`gepa_adk.adapters.execution.agent_executor`][gepa_adk.adapters.execution.agent_executor]:
         AgentExecutor implementation.
 
-Note:
+Notes:
     This module follows hexagonal architecture principles. The protocol
     is defined here in the ports layer, while implementations live in
     the adapters layer.
@@ -69,7 +69,7 @@ class ExecutionStatus(str, Enum):
             print(f"Error: {result.error_message}")
         ```
 
-    Note:
+    Notes:
         All status values reflect execution outcome, not output quality.
         A successful execution may still produce low-quality output
         that fails scoring.
@@ -121,7 +121,7 @@ class ExecutionResult:
         )
         ```
 
-    Note:
+    Notes:
         All captured_events contain raw ADK Event objects for debugging
         and trajectory recording. Events are captured even on timeout
         or failure.
@@ -180,7 +180,7 @@ class AgentExecutorProtocol(Protocol):
         - [`ExecutionStatus`][gepa_adk.ports.agent_executor.ExecutionStatus]:
             Status enum for execution outcomes.
 
-    Note:
+    Notes:
         All implementations should validate that the agent parameter is a
         valid ADK LlmAgent. The Any type is used here to avoid coupling
         the ports layer to ADK types.
@@ -270,7 +270,7 @@ class AgentExecutorProtocol(Protocol):
             )
             ```
 
-        Note:
+        Notes:
             The agent parameter is typed as Any to avoid coupling to ADK types
             in the ports layer. Implementations should validate that the agent
             is a valid LlmAgent.

--- a/src/gepa_adk/ports/agent_provider.py
+++ b/src/gepa_adk/ports/agent_provider.py
@@ -51,7 +51,7 @@ See Also:
         Executes agents loaded by a provider.
     - [`gepa_adk.engine`][gepa_adk.engine]: Evolution engine that consumes agent providers.
 
-Note:
+Notes:
     The protocol uses sync methods for simplicity. Implementations that need
     async can use async internally and block in sync methods, or provide
     async wrappers. The protocol itself does not perform I/O; implementations
@@ -109,7 +109,7 @@ class AgentProvider(Protocol):
         assert isinstance(provider, AgentProvider)  # Runtime check works
         ```
 
-    Note:
+    Notes:
         All implementations must provide get_agent(), save_instruction(),
         and list_agents() methods. Use @runtime_checkable to enable
         isinstance() checks for protocol compliance.
@@ -137,7 +137,7 @@ class AgentProvider(Protocol):
             print(agent.instruction)
             ```
 
-        Note:
+        Notes:
             Only non-empty names are accepted. Configured agents ready
             for use with the evolution system should be returned.
         """
@@ -164,7 +164,7 @@ class AgentProvider(Protocol):
             )
             ```
 
-        Note:
+        Notes:
             Only after successful persistence should subsequent calls to
             get_agent() return an agent with the updated instruction.
             Implementations should validate empty names before processing.
@@ -186,7 +186,7 @@ class AgentProvider(Protocol):
                 print(f"Found agent: {name}")
             ```
 
-        Note:
+        Notes:
             Ordering of returned names is not guaranteed by the protocol.
             Some implementations may return names in a specific order,
             but callers should not rely upon any particular sequence.

--- a/src/gepa_adk/ports/candidate_selector.py
+++ b/src/gepa_adk/ports/candidate_selector.py
@@ -39,7 +39,7 @@ from gepa_adk.domain.state import ParetoState
 class CandidateSelectorProtocol(Protocol):
     """Async protocol for candidate selection strategies.
 
-    Note:
+    Notes:
         Adapters implementing this protocol provide strategies for selecting
         candidates from the Pareto frontier for mutation.
 
@@ -63,7 +63,7 @@ class CandidateSelectorProtocol(Protocol):
         Raises:
             NoCandidateAvailableError: If state has no candidates.
 
-        Note:
+        Notes:
             Outputs a candidate index from the frontier for mutation,
             enabling Pareto-aware selection strategies.
 

--- a/src/gepa_adk/ports/component_handler.py
+++ b/src/gepa_adk/ports/component_handler.py
@@ -37,7 +37,7 @@ See Also:
     - [`adk_adapter`][gepa_adk.adapters.evolution.adk_adapter]:
         Usage in ADKAdapter._apply_candidate().
 
-Note:
+Notes:
     This protocol follows the hexagonal architecture pattern - it is defined
     in ports/ with no external dependencies. Implementations go in adapters/
     to maintain clean layer separation.
@@ -97,7 +97,7 @@ class ComponentHandler(Protocol):
 [gepa_adk.adapters.components.component_handlers.OutputSchemaHandler]:
             Handler for agent output schema.
 
-    Note:
+    Notes:
         All methods are synchronous - no I/O operations should be performed.
         Apply() should log warnings and keep the original value rather than
         raising exceptions on invalid inputs for error safety.
@@ -120,7 +120,7 @@ class ComponentHandler(Protocol):
             # text == "You are a helpful assistant."
             ```
 
-        Note:
+        Notes:
             Operations must never raise exceptions for missing values.
             Return empty string or sensible default instead.
         """
@@ -145,7 +145,7 @@ class ComponentHandler(Protocol):
             # original contains previous instruction value
             ```
 
-        Note:
+        Notes:
             On application failure (e.g., invalid schema), log warning
             and return original without modifying agent. Never raise
             exceptions - graceful degradation is required.
@@ -168,7 +168,7 @@ class ComponentHandler(Protocol):
             # agent.instruction is back to original value
             ```
 
-        Note:
+        Notes:
             Original value restoration always succeeds - never raises exceptions.
             None values reset to component default.
         """

--- a/src/gepa_adk/ports/component_selector.py
+++ b/src/gepa_adk/ports/component_selector.py
@@ -36,7 +36,7 @@ from typing import Protocol, runtime_checkable
 class ComponentSelectorProtocol(Protocol):
     """Async protocol for component selection strategies.
 
-    Note:
+    Notes:
         Adapters implementing this protocol determine which candidate components
         to update during mutation, enabling flexible evolution strategies.
 
@@ -66,7 +66,7 @@ class ComponentSelectorProtocol(Protocol):
         Raises:
             ValueError: If components list is empty.
 
-        Note:
+        Notes:
             Outputs a list of component keys to update, enabling selective
             mutation of specific candidate components.
 

--- a/src/gepa_adk/ports/evaluation_policy.py
+++ b/src/gepa_adk/ports/evaluation_policy.py
@@ -53,7 +53,7 @@ class EvaluationPolicyProtocol(Protocol):
     Determines which validation examples to evaluate per iteration
     and how to identify the best candidate based on evaluation results.
 
-    Note:
+    Notes:
         Adapters implementing this protocol control evaluation cost and
         candidate selection strategies for scalable evolution runs.
 
@@ -90,7 +90,7 @@ class EvaluationPolicyProtocol(Protocol):
             List of example indices to evaluate this iteration.
             Must be a subset of valset_ids (or equal).
 
-        Note:
+        Notes:
             Outputs a list of valset indices to evaluate, which may be a subset
             or the full valset depending on the policy implementation.
 
@@ -114,7 +114,7 @@ class EvaluationPolicyProtocol(Protocol):
         Raises:
             NoCandidateAvailableError: If state has no candidates.
 
-        Note:
+        Notes:
             Outputs the index of the best candidate based on the policy's
             scoring strategy (e.g., highest average score).
 
@@ -136,7 +136,7 @@ class EvaluationPolicyProtocol(Protocol):
             Aggregated score (typically mean across evaluated examples).
             Returns float('-inf') if candidate has no evaluated scores.
 
-        Note:
+        Notes:
             Outputs an aggregated score for the candidate, typically the mean
             across evaluated examples, or negative infinity if no scores exist.
 

--- a/src/gepa_adk/ports/evolution_result.py
+++ b/src/gepa_adk/ports/evolution_result.py
@@ -51,7 +51,7 @@ See Also:
     - [`gepa_adk.ports.adapter`][gepa_adk.ports.adapter]: Adapter protocol
         that produces evolution results.
 
-Note:
+Notes:
     The protocol deliberately excludes mode-specific fields
     (``valset_score``, ``primary_agent``). Consumers needing those fields
     should use the concrete result types directly.

--- a/src/gepa_adk/ports/proposer.py
+++ b/src/gepa_adk/ports/proposer.py
@@ -35,7 +35,7 @@ See Also:
     - [`ParetoState`][gepa_adk.domain.state.ParetoState]: Evolution state consumed by proposers.
     - [`ProposalResult`][gepa_adk.domain.types.ProposalResult]: Return type for proposals.
 
-Note:
+Notes:
     This module defines the protocol interface for candidate proposal strategies.
     All proposers return None when no valid proposal can be generated.
     Implementations should be idempotent and not modify state.
@@ -57,7 +57,7 @@ class ProposerProtocol(Protocol):
     Proposers generate new candidates for evolution. The two main implementations
     are mutation-based (reflective improvement) and merge-based (genetic crossover).
 
-    Note:
+    Notes:
         Attributes are not required by this protocol. Implementations may define
         configuration attributes as needed.
 
@@ -73,7 +73,7 @@ class ProposerProtocol(Protocol):
                 return ProposalResult(candidate=..., parent_indices=[...], tag="custom")
         ```
 
-    Note:
+    Notes:
         All proposers return None when no valid proposal can be generated.
     """
 
@@ -115,7 +115,7 @@ class ProposerProtocol(Protocol):
                     )
             ```
 
-        Note:
+        Notes:
             Operations must be idempotent and not modify state. The method should
             be safe to call multiple times with the same state without side effects.
         """

--- a/src/gepa_adk/ports/scorer.py
+++ b/src/gepa_adk/ports/scorer.py
@@ -49,7 +49,7 @@ See Also:
     - [`gepa_adk.adapters`][gepa_adk.adapters]: Scorer implementations
         (e.g., CriticScorer, exact-match scorers).
 
-Note:
+Notes:
     The protocol defines both synchronous and asynchronous scoring methods
     to support various use cases. Score values should be normalized between
     0.0 and 1.0 by convention, with higher values indicating better performance.
@@ -102,7 +102,7 @@ class Scorer(Protocol):
         assert isinstance(scorer, Scorer)  # Runtime check works
         ```
 
-    Note:
+    Notes:
         All implementations must provide both score() and async_score()
         methods to satisfy the protocol. Score values should be normalized
         between 0.0 and 1.0 by convention, with higher values indicating
@@ -146,7 +146,7 @@ class Scorer(Protocol):
             # Scorer evaluates based on quality criteria, not exact match
             ```
 
-        Note:
+        Notes:
             Operations complete synchronously and block until scoring finishes.
             Use async_score() for I/O-bound operations like LLM calls.
         """
@@ -193,7 +193,7 @@ class Scorer(Protocol):
             scores = await asyncio.gather(*tasks)
             ```
 
-        Note:
+        Notes:
             Operations run asynchronously and can be executed concurrently.
             Prefer this method for I/O-bound scoring operations such as
             LLM-based evaluation or external API calls.

--- a/src/gepa_adk/ports/stopper.py
+++ b/src/gepa_adk/ports/stopper.py
@@ -32,7 +32,7 @@ See Also:
     - [`StopperState`][gepa_adk.domain.stopper.StopperState]: State snapshot passed to stoppers.
     - [`gepa_adk.adapters.stoppers`][gepa_adk.adapters.stoppers]: Built-in stopper implementations.
 
-Note:
+Notes:
     This protocol is runtime_checkable, allowing isinstance() checks
     to work without explicit inheritance and follows the structural
     typing pattern used throughout gepa-adk's ports layer.
@@ -83,7 +83,7 @@ class StopperProtocol(Protocol):
         isinstance(score_threshold_stopper, StopperProtocol)  # True
         ```
 
-    Note:
+    Notes:
         All stoppers should be pure functions of their input state - they
         ought not have side effects or depend on external mutable state for
         deterministic behavior.
@@ -99,7 +99,7 @@ class StopperProtocol(Protocol):
         Returns:
             True if evolution should stop, False to continue.
 
-        Note:
+        Notes:
             Often this method is called after each iteration. Return True as
             soon as the stop condition is met to avoid unnecessary computation.
         """

--- a/src/gepa_adk/ports/video_blob_service.py
+++ b/src/gepa_adk/ports/video_blob_service.py
@@ -48,7 +48,7 @@ See Also:
     - [`VideoFileInfo`][gepa_adk.domain.models.VideoFileInfo]: Metadata returned by validation.
     - [`gepa_adk.adapters.media`][gepa_adk.adapters.media]: Video blob service implementations.
 
-Note:
+Notes:
     The protocol uses list[Any] as the return type for prepare_video_parts()
     to avoid importing ADK types in the ports layer. Implementations in the
     adapters layer return google.genai.types.Part objects.
@@ -105,7 +105,7 @@ class VideoBlobServiceProtocol(Protocol):
         assert isinstance(service, VideoBlobServiceProtocol)
         ```
 
-    Note:
+    Notes:
         All implementations must provide both prepare_video_parts() and
         validate_video_file() methods. Video size is limited to 2GB per
         the Gemini API constraint. Only video/* MIME types are accepted.
@@ -155,7 +155,7 @@ class VideoBlobServiceProtocol(Protocol):
             # parts[0] is intro, parts[1] is main, parts[2] is outro
             ```
 
-        Note:
+        Notes:
             Operations include async file I/O for reading video bytes.
             Video files are validated before loading to provide early
             failure with clear error messages.
@@ -206,7 +206,7 @@ class VideoBlobServiceProtocol(Protocol):
                 print(f"Invalid: {e.video_path} - {e.constraint}")
             ```
 
-        Note:
+        Notes:
             Operates synchronously for fast pre-validation without async
             context. File content is not read, only metadata is checked.
         """

--- a/src/gepa_adk/utils/__init__.py
+++ b/src/gepa_adk/utils/__init__.py
@@ -41,7 +41,7 @@ See Also:
     - [`gepa_adk.domain.trajectory`][gepa_adk.domain.trajectory]:
       Trajectory domain models
 
-Note:
+Notes:
     These utilities are infrastructure concerns, not domain logic.
     They consume domain models but don't define them.
 """

--- a/src/gepa_adk/utils/encoding.py
+++ b/src/gepa_adk/utils/encoding.py
@@ -41,7 +41,7 @@ See Also:
     - [`structlog.dev.ConsoleRenderer`][structlog.dev.ConsoleRenderer]: Renderer
       that this processor should precede in the chain.
 
-Note:
+Notes:
     This processor is designed to be transparent on UTF-8 consoles (macOS,
     Linux) while preventing crashes on cp1252 consoles (Windows).
 """
@@ -84,7 +84,7 @@ class EncodingSafeProcessor:
         # result["event"] == "User said 'hello'"
         ```
 
-    Note:
+    Notes:
         All sanitization is idempotent - processing already-sanitized strings
         produces identical output.
     """
@@ -111,7 +111,7 @@ class EncodingSafeProcessor:
         to UTF-8 if detection fails (e.g., when stdout is redirected or
         unavailable).
 
-        Note:
+        Notes:
             Console encoding is cached at initialization time to avoid
             repeated attribute lookups during log processing.
         """
@@ -140,7 +140,7 @@ class EncodingSafeProcessor:
             The event_dict with all string values sanitized for console
             encoding compatibility.
 
-        Note:
+        Notes:
             Original event_dict is not modified; a new dict is returned
             with sanitized values.
         """
@@ -169,7 +169,7 @@ class EncodingSafeProcessor:
             assert result == "User said 'hello'"
             ```
 
-        Note:
+        Notes:
             Order of operations: smart replacements run first to preserve
             semantic meaning, then encode/decode handles remaining characters.
         """

--- a/src/gepa_adk/utils/events.py
+++ b/src/gepa_adk/utils/events.py
@@ -41,7 +41,7 @@ See Also:
     - [`gepa_adk.domain.types`][gepa_adk.domain.types]:
       Configuration (TrajectoryConfig)
 
-Note:
+Notes:
     These utilities handle infrastructure concerns like data transformation
     and security (redaction), not domain logic. They consume domain models
     but don't define them.
@@ -110,7 +110,7 @@ def _redact_sensitive(
         # result == {"password": "[REDACTED]", "token": "[REDACTED]", "name": "user"}
         ```
 
-    Note:
+    Notes:
         Strict exact key matching is used (case-sensitive). For example,
         "password" will not match "Password" or "user_password".
         Original data structure is never modified.
@@ -189,7 +189,7 @@ def _truncate_strings(
         # result["results"][1]["content"] == "b" * 50
         ```
 
-    Note:
+    Notes:
         String values are the only type truncated. Numbers, booleans, None,
         and other types pass through unchanged. Original data is never modified.
         Marker format is "...[truncated N chars]" where N is chars removed.
@@ -234,7 +234,7 @@ def _extract_tool_calls(events: list[Any]) -> tuple[ToolCallRecord, ...]:
         # tool_calls[0].arguments == {"query": "AI"}
         ```
 
-    Note:
+    Notes:
         Supports both real ADK Events and test mocks gracefully. Tool calls
         without responses are recorded with result=None. Function calls
         are extracted from Event.actions.function_calls if present.
@@ -322,7 +322,7 @@ def _extract_state_deltas(events: list[Any]) -> tuple[dict[str, Any], ...]:
         # state_deltas[0] == {"search_count": 1}
         ```
 
-    Note:
+    Notes:
         Skips events with None or missing state_delta attributes. State deltas
         capture changes to session or agent state during execution. The research
         document notes that ADK provides the delta (new values) not before/after.
@@ -363,7 +363,7 @@ def _extract_token_usage(events: list[Any]) -> TokenUsage | None:
             print(f"Total tokens: {token_usage.total_tokens}")
         ```
 
-    Note:
+    Notes:
         Searches for usage_metadata attributes on events. Maps ADK fields:
         - prompt_token_count → input_tokens
         - candidates_token_count → output_tokens
@@ -476,7 +476,7 @@ def extract_final_output(
         output = extract_final_output(events, prefer_concatenated=True)
         ```
 
-    Note:
+    Notes:
         Scans events for is_final_response()=True, filters thought parts,
         skips empty/None text, and handles missing attributes gracefully.
         Response source priority: response_content > content.parts. Default
@@ -650,7 +650,7 @@ def extract_trajectory(
         )
         ```
 
-    Note:
+    Notes:
         Extraction follows this order:
         1. Extract raw data from events (tool calls, state, tokens)
         2. Apply redaction if config.redact_sensitive is True
@@ -788,7 +788,7 @@ def extract_output_from_state(
         # result is None
         ```
 
-    Note:
+    Notes:
         State-based extraction complements event-based extraction for ADK's
         output_key mechanism. Callers should implement fallback logic
         (e.g., extract_final_output) when this function returns None.
@@ -840,7 +840,7 @@ def partition_events_by_agent(events: list[Any]) -> dict[str, list[Any]]:
             trajectories[agent_name] = extract_trajectory(agent_events)
         ```
 
-    Note:
+    Notes:
         Sorts events into agent-specific lists by examining `event.author`.
         User events are excluded since they represent input, not agent output.
     """

--- a/src/gepa_adk/utils/schema_tools.py
+++ b/src/gepa_adk/utils/schema_tools.py
@@ -120,7 +120,7 @@ def validate_output_schema(schema_text: str) -> dict[str, Any]:
         - [`validate_schema_text()`][gepa_adk.utils.schema_utils.validate_schema_text]:
           Core validation function.
 
-    Note:
+    Notes:
         This function never raises exceptions - validation errors are returned
         in the dict result with `valid=False`. This ensures ADK tools can always
         return successfully and let the LLM handle the error.

--- a/src/gepa_adk/utils/schema_utils.py
+++ b/src/gepa_adk/utils/schema_utils.py
@@ -48,7 +48,7 @@ See Also:
       Exception raised for validation failures.
     - [Single-Agent Evolution Guide](../../../guides/single-agent.md): Usage in evolution workflows.
 
-Note:
+Notes:
     The validation pipeline uses AST parsing before controlled exec() to prevent
     arbitrary code execution. Import statements and function definitions
     are explicitly rejected.
@@ -437,8 +437,6 @@ def validate_schema_text(
     Args:
         schema_text (str): Python source code defining a Pydantic model.
             May be wrapped in markdown code fences (` ```python...``` `).
-
-    Other Parameters:
         allowed_namespace (dict[str, Any] | None): Override default namespace.
             If None, uses SCHEMA_NAMESPACE.
 
@@ -570,7 +568,7 @@ def _extract_field_type(schema: type[BaseModel], field_name: str) -> type | None
         The Python type of the field, or None if field not found.
         For Optional[T] or T | None, returns T (the non-None type).
 
-    Note:
+    Notes:
         Schema fields use Pydantic FieldInfo - this extracts the annotation.
         For Optional types, extracts the inner non-None type.
     """
@@ -620,7 +618,7 @@ def _is_type_compatible(
     Returns:
         True if actual_type matches any allowed type.
 
-    Note:
+    Notes:
         Subclass relationships are checked via issubclass. A type is compatible
         if it's the same as or a subclass of an allowed type.
     """
@@ -695,7 +693,7 @@ def validate_schema_against_constraints(
         )
         ```
 
-    Note:
+    Notes:
         Once original_schema is None, validation is short-circuited because we cannot
         validate against a missing baseline model. Only constraint checks whose fields
         exist on the original schema are evaluated; constraint entries targeting missing

--- a/src/gepa_adk/utils/state_guard.py
+++ b/src/gepa_adk/utils/state_guard.py
@@ -27,7 +27,7 @@ See Also:
     - [`gepa_adk.engine.reflection`][gepa_adk.engine.reflection]: Reflection
       engine whose output is validated by StateGuard.
 
-Note:
+Notes:
     This utility ensures ADK state injection tokens (e.g., {user_id}) remain
     functional after LLM reflection modifies component_text. Tokens must be
     present in both the original component_text and required_tokens list to be
@@ -74,7 +74,7 @@ class StateGuard:
         # result == "Process for {user_id} with {{malicious}}"
         ```
 
-    Note:
+    Notes:
         All validation logic is stateless and operates on string inputs only.
         No external dependencies or I/O operations are performed.
 
@@ -102,10 +102,10 @@ class StateGuard:
             escape_unauthorized: If True, escape new unauthorized tokens.
                 Defaults to True.
 
-        Note:
-            Configuration determines which tokens are protected and which
-            behaviors are enabled. Both repair and escape are enabled by default
-            for maximum safety.
+        Notes:
+            The constructor arguments determine which tokens are protected and
+            which behaviors are enabled. Both repair and escape are enabled by
+            default for maximum safety.
         """
         self.required_tokens = required_tokens or []
         self.repair_missing = repair_missing
@@ -122,7 +122,7 @@ class StateGuard:
             Set of token names (without braces), including full token content
             for prefixed and optional tokens (e.g., "app:settings", "name?").
 
-        Note:
+        Notes:
             Scans text using the regex pattern
             `(?<!\{)\{(\w+(?::\w+)?(?:\?)?)\}(?!\})`.
 
@@ -166,7 +166,7 @@ class StateGuard:
             # escaped == ["{malicious}"]
             ```
 
-        Note:
+        Notes:
             Outputs what validate() would repair or escape given the
             current configuration and inputs, using the same token detection
             logic as validate(), without modifying the component_text.
@@ -225,7 +225,7 @@ class StateGuard:
             # result == "Process {user_id} {{malicious}}"
             ```
 
-        Note:
+        Notes:
             Only tokens present in both the original component_text and the
             required_tokens list are eligible for repair. New tokens not in
             required_tokens are escaped by default.

--- a/uv.lock
+++ b/uv.lock
@@ -507,14 +507,14 @@ wheels = [
 
 [[package]]
 name = "docvet"
-version = "1.11.0"
+version = "1.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/4e/3503462bc15263ad1a744ad2e5bff3d38d50797a1b2999e6475d9a83f776/docvet-1.11.0.tar.gz", hash = "sha256:510fba480650c3ee7201f3fb99be89f25a08cf87e3331810ce3963a1ca14158a", size = 56088, upload-time = "2026-03-07T00:03:19.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/d4/5eded08c29cfa6f844e2bcf23c738d1026dce74d564153ec683211ea8e34/docvet-1.15.1.tar.gz", hash = "sha256:4e22d9f81d2b8e06d453c70d95a4d238f146ed3c31518b6811912aa30a4fce6b", size = 87800, upload-time = "2026-05-08T21:34:07.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/3d/11edadce56d90563ea56dd9237253b1b00e539ea34b8ec54864c24286b11/docvet-1.11.0-py3-none-any.whl", hash = "sha256:c00069ae752e259480bf36624e3f03828fbcbc4fa0e0f9e8fbd29b8a30456f03", size = 64527, upload-time = "2026-03-07T00:03:20.502Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5b/03daeb7b4406179c281837c7f3731e82c675a706cb7f9e8252b438221dd2/docvet-1.15.1-py3-none-any.whl", hash = "sha256:e332b40473d3710527ebf38bf5a0ff5559b0a198e028fdacff2389f22a488b48", size = 107079, upload-time = "2026-05-08T21:34:05.939Z" },
 ]
 
 [package.optional-dependencies]
@@ -694,6 +694,7 @@ dev = [
     { name = "cairosvg" },
     { name = "docvet", extra = ["lsp", "mcp"] },
     { name = "gepa" },
+    { name = "griffe" },
     { name = "griffe-inherited-docstrings" },
     { name = "griffe-warnings-deprecated" },
     { name = "mkdocs-ezglossary-plugin" },
@@ -735,8 +736,9 @@ requires-dist = [
 dev = [
     { name = "arize-phoenix-client" },
     { name = "cairosvg", specifier = ">=2.7.1" },
-    { name = "docvet", extras = ["lsp", "mcp"], specifier = ">=1.11.0" },
+    { name = "docvet", extras = ["lsp", "mcp"], specifier = ">=1.15.1" },
     { name = "gepa", specifier = ">=0.0.24" },
+    { name = "griffe", specifier = ">=2.0.2" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.1.2" },
     { name = "griffe-warnings-deprecated", specifier = ">=1.1.0" },
     { name = "mkdocs-ezglossary-plugin", specifier = ">=2.1.0" },
@@ -1409,6 +1411,19 @@ wheels = [
 ]
 
 [[package]]
+name = "griffe"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/49/eb6d2935e27883af92c930ed40cc4c69bcd32c402be43b8ca4ab20510f67/griffe-2.0.2.tar.gz", hash = "sha256:c5d56326d159f274492e9bf93a9895cec101155d944caa66d0fc4e0c13751b92", size = 293757, upload-time = "2026-03-27T11:34:52.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/c0/2bb018eecf9a83c68db9cd9fffd9dab25f102ad30ed869451046e46d1187/griffe-2.0.2-py3-none-any.whl", hash = "sha256:2b31816460aee1996af26050a1fc6927a2e5936486856707f55508e4c9b5960b", size = 5141, upload-time = "2026-03-27T11:34:47.721Z" },
+]
+
+[[package]]
 name = "griffe-inherited-docstrings"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1433,12 +1448,25 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.0.0"
+name = "griffecli"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/e0/6a7d661d71bb043656a109b91d84a42b5342752542074ec83b16a6eb97f0/griffecli-2.0.2.tar.gz", hash = "sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb", size = 56281, upload-time = "2026-03-27T11:34:50.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/90d93356c88ac34c20cb5edffca68138df55ca9bbd1a06eccfbcec8fdbe5/griffecli-2.0.2-py3-none-any.whl", hash = "sha256:0d44d39e59afa81e288a3e1c3bf352cc4fa537483326ac06b8bb6a51fd8303a0", size = 9500, upload-time = "2026-03-27T11:34:48.81Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The CI docvet job was failing on 27 ``extra-param-in-docstring`` findings across 11 files, none of which were real parameter mismatches. Root cause: docvet 1.15 only recognizes the plural ``Notes:`` section header (along with the rest of the Google/NumPy canonical headers), and the codebase used the singular ``Note:`` everywhere. Anything under ``Note:`` was being parsed as trailing content of the preceding ``Args:`` section, so the first capital noun in each Notes block looked like an undocumented param to docvet. The local pre-commit hook was running docvet 1.11 (which still tolerated ``Note:``), so it only surfaced in CI when the action installed docvet @ latest.

- Rename every ``Note:`` section header to ``Notes:`` across 60 source modules
- Pin ``docvet[lsp,mcp]>=1.15.1`` so local pre-commit matches what the CI action installs; add ``griffe`` as a dev dep so docvet's griffe check no longer skips
- Set ``[tool.docvet.enrichment]`` ``exclude-args-kwargs = false`` and ``require-other-parameters = false`` so docvet aligns with ruff D417 (document ``*args``/``**kwargs`` inline in Args)
- Move ``**context`` / ``**kwargs`` documentation from ``Other Parameters`` into ``Args`` for the few functions that had it, and delete the redundant ``Note: Context fields use keyword-only...`` boilerplate from 12 exception ``__init__`` docstrings (the signatures already make the keyword-only intent clear)

Test: ``uv run docvet check --all`` (0 findings, 100% coverage) + ``uv run ruff check .`` + ``uv run pytest`` (2124 passed, 1 skipped)

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [x] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Two judgment calls worth a look:
1. **Bulk ``Note:`` → ``Notes:`` rename** (60 files) — applied via a strict ``sed`` only matching the standalone section-header line (``^[[:space:]]*Note:[[:space:]]*$``); confirm no in-prose ``Note:`` was touched.
2. **Docvet/ruff D417 reconciliation** — chose to document ``*args``/``**kwargs`` inline in Args (matching ruff's preference) instead of in a separate Other Parameters section. The two docvet toggles in pyproject.toml carry an explanatory comment for future maintainers.

### Related
Unblocks #316 docvet check. Follows #332 (dep bumps) — together they make CI green again on the RegressionStopper PR.